### PR TITLE
Add user agent string to HTTP requests, and add tests around the debugging audit log class

### DIFF
--- a/Sources/OktaIdx/Internal/Implementations/Version1/Debugging/URLSessionAudit.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Debugging/URLSessionAudit.swift
@@ -16,8 +16,8 @@ import Foundation
 
 public class URLSessionAudit: CustomStringConvertible {
     static let shared = URLSessionAudit()
-    private let queue = DispatchQueue(label: "com.okta.urlsession.audit")
-    private var logs: [Log] = []
+    internal let queue = DispatchQueue(label: "com.okta.urlsession.audit", qos: .utility)
+    public private(set) var logs: [Log] = []
     
     func reset() {
         queue.sync {
@@ -31,7 +31,7 @@ public class URLSessionAudit: CustomStringConvertible {
         }
     }
     
-    struct Log: CustomStringConvertible {
+    public struct Log: CustomStringConvertible {
         let date: Date
         let url: URL?
         let method: String?
@@ -55,7 +55,7 @@ public class URLSessionAudit: CustomStringConvertible {
             responseBody = data
         }
 
-        var description: String {
+        public var description: String {
             let requestString: String
             if let body = requestBody {
                 requestString = String(data: body, encoding: .utf8) ?? "<invalid data>"

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Protocols/RequestHTTPHeaders.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Protocols/RequestHTTPHeaders.swift
@@ -13,18 +13,40 @@
 import Foundation
 
 protocol HasHTTPHeaders {
+    var userAgent: String { get }
     var httpHeaders: [String:String] { get }
 }
 
 protocol HasOAuthHTTPHeaders: HasHTTPHeaders {}
 protocol HasIDPHTTPHeaders: HasHTTPHeaders {}
 
+private let SharedUserAgent: String = {
+    return buildUserAgent()
+}()
+
+extension HasHTTPHeaders {
+    var userAgent: String {
+        get {
+            return SharedUserAgent
+        }
+    }
+    
+    var httpHeaders: [String : String] {
+        get {
+            return [
+                "User-Agent": userAgent
+            ]
+        }
+    }
+}
+
 extension HasOAuthHTTPHeaders {
     var httpHeaders: [String : String] {
         get {
             return [
                 "Content-Type": "application/x-www-form-urlencoded",
-                "Accept": "application/json"
+                "Accept": "application/json",
+                "User-Agent": userAgent
             ]
         }
     }
@@ -35,7 +57,8 @@ extension HasIDPHTTPHeaders {
         get {
             return [
                 "Content-Type": "application/ion+json; okta-version=1.0.0",
-                "Accept": "application/ion+json; okta-version=1.0.0"
+                "Accept": "application/ion+json; okta-version=1.0.0",
+                "User-Agent": userAgent
             ]
         }
     }

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Requests/RemediationRequest.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Requests/RemediationRequest.swift
@@ -37,13 +37,10 @@ extension IDXClient.APIVersion1.RemediationRequest: IDXClientAPIRequest, Receive
         var request = URLRequest(url: href)
         request.httpMethod = method
         request.httpBody = data
-        request.addValue(accepts.stringValue(), forHTTPHeaderField: "Content-Type")
-
-        if let requestHasHeaders = self as? HasHTTPHeaders {
-            requestHasHeaders.httpHeaders.forEach { (key, value) in
-                request.addValue(value, forHTTPHeaderField: key)
-            }
+        httpHeaders.forEach { (key, value) in
+            request.addValue(value, forHTTPHeaderField: key)
         }
+        request.setValue(accepts.stringValue(), forHTTPHeaderField: "Content-Type")
 
         return request
     }

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Responses/Responses.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Responses/Responses.swift
@@ -49,7 +49,7 @@ extension IDXClient.APIVersion1 {
         let parameters: [String:Any]
     }
     
-    struct RemediationRequest {
+    struct RemediationRequest: HasHTTPHeaders {
         let method: String
         let href: URL
         let accepts: AcceptType

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Utilities/UserAgent.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Utilities/UserAgent.swift
@@ -1,0 +1,61 @@
+//
+//  UserAgent.swift
+//  okta-idx-ios
+//
+//  Created by Mike Nachbaur on 2021-02-11.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+internal func deviceModel() -> String {
+    var system = utsname()
+    uname(&system)
+    let model = withUnsafePointer(to: &system.machine.0) { ptr in
+        return String(cString: ptr)
+    }
+    return model
+}
+
+internal func buildUserAgent() -> String {
+    var components: [String] = []
+    
+    // IDX framework version
+    if let infoDictionary = Bundle(for: IDXClient.self).infoDictionary,
+       let version = infoDictionary["CFBundleShortVersionString"] as? String
+    {
+        components.append("okta-idx-swift/\(version)")
+    }
+    
+    // Main app version
+    if let infoDictionary = Bundle.main.infoDictionary,
+       let version = infoDictionary["CFBundleShortVersionString"] ?? infoDictionary[kCFBundleVersionKey as String] as? String,
+       let name = infoDictionary["CFBundleName"] as? String
+    {
+        components.append("\(name)/\(version)")
+    }
+
+    // CFNetwork version (since that's included in the default useragent string)
+    if let infoDictionary = Bundle(identifier: "com.apple.CFNetwork")?.infoDictionary,
+       let version = infoDictionary[kCFBundleVersionKey as String] as? String
+    {
+        components.append("CFNetwork/\(version)")
+    }
+
+    // Device model
+    components.append("Device/\(deviceModel())")
+
+    // OS type and version
+    #if canImport(UIKit)
+    let osName = UIDevice.current.systemName
+    let osVersion = UIDevice.current.systemVersion
+    components.append("\(osName)/\(osVersion)")
+    #elseif os(macOS)
+    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+    components.append("macOS/\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)")
+    #endif
+    
+    return components.joined(separator: " ")
+}

--- a/Tests/IDXClientRequestTests.swift
+++ b/Tests/IDXClientRequestTests.swift
@@ -30,10 +30,9 @@ class IDXClientRequestTests: XCTestCase {
         let url = urlRequest?.url?.absoluteString
         XCTAssertEqual(url, "https://example.com/issuer/oauth2/default/v1/interact")
         
-        XCTAssertEqual(urlRequest?.allHTTPHeaderFields, [
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Accept": "application/json"
-        ])
+        XCTAssertEqual(urlRequest?.allHTTPHeaderFields?["Content-Type"], "application/x-www-form-urlencoded")
+        XCTAssertEqual(urlRequest?.allHTTPHeaderFields?["Accept"], "application/json")
+        XCTAssertNotNil(urlRequest?.allHTTPHeaderFields?["User-Agent"])
 
         let data = urlRequest?.httpBody?.urlFormEncoded()
         XCTAssertNotNil(data)

--- a/Tests/URLSessionAuditTests.swift
+++ b/Tests/URLSessionAuditTests.swift
@@ -1,0 +1,47 @@
+//
+//  URLSessionAuditTests.swift
+//  okta-idx-ios-tests
+//
+//  Created by Mike Nachbaur on 2021-02-11.
+//
+
+import XCTest
+@testable import OktaIdx
+
+class URLSessionAuditTests: XCTestCase {
+    func testAuditLog() {
+        let audit = URLSessionAudit()
+        
+        XCTAssertEqual(audit.logs.count, 0)
+        
+        let url = URL(string: "https://example.com/foo")!
+        let request = URLRequest(url: url)
+        let response = HTTPURLResponse(url: url,
+                                       statusCode: 200,
+                                       httpVersion: "1.1",
+                                       headerFields: [ "foo": "bar" ])
+        let data = "Response".data(using: .utf8)
+        
+        audit.add(log: .init(with: request, response: response, body: data))
+        
+        let addExpectation = expectation(description: "Wait for the item to be added")
+        audit.queue.sync {
+            addExpectation.fulfill()
+        }
+        wait(for: [addExpectation], timeout: 1)
+        
+        XCTAssertEqual(audit.logs.count, 1)
+        
+        XCTAssertEqual(audit.description, """
+            GET https://example.com/foo
+            Request Body:
+            <no request body>
+            Status code: 200
+            Response
+
+            """)
+
+        audit.reset()
+        XCTAssertEqual(audit.logs.count, 0)
+    }
+}

--- a/Tests/UserAgentTests.swift
+++ b/Tests/UserAgentTests.swift
@@ -1,0 +1,75 @@
+//
+//  UserAgentTests.swift
+//  okta-idx-ios-tests
+//
+//  Created by Mike Nachbaur on 2021-02-11.
+//
+
+import XCTest
+@testable import OktaIdx
+
+class UserAgentTests: XCTestCase {
+    var regex: NSRegularExpression!
+    
+    override func setUpWithError() throws {
+        let pattern = "okta-idx-swift/[\\d\\.]+ xctest/\\d+ CFNetwork/\\d+ Device/\\S+ (iOS|watchOS|tvOS|macOS)/[\\d\\.]+"
+        regex = try NSRegularExpression(pattern: pattern, options: [])
+    }
+    
+    func regexMatch(in userAgent: String?) -> NSTextCheckingResult? {
+        guard let userAgent = userAgent else { return nil }
+        
+        let range = NSRange(location: 0, length: userAgent.count)
+        return regex.firstMatch(in: userAgent, options: [], range: range)
+    }
+    
+    func testUserAgent() throws {
+        let userAgent = buildUserAgent()
+        XCTAssertNotNil(userAgent)
+        
+        let match = regexMatch(in: userAgent)
+        XCTAssertNotNil(match)
+    }
+    
+    func testInteractRequest() {
+        let request = IDXClient.APIVersion1.InteractRequest(codeChallenge: "challenge")
+        let userAgent = request.httpHeaders["User-Agent"]
+        XCTAssertNotNil(userAgent)
+
+        let match = regexMatch(in: userAgent)
+        XCTAssertNotNil(match)
+    }
+
+    func testIntrospectRequest() {
+        let request = IDXClient.APIVersion1.IntrospectRequest(interactionHandle: "abc123")
+        let userAgent = request.httpHeaders["User-Agent"]
+        XCTAssertNotNil(userAgent)
+
+        let match = regexMatch(in: userAgent)
+        XCTAssertNotNil(match)
+    }
+    
+    func testTokenRequest() {
+        let request = IDXClient.APIVersion1.TokenRequest(method: "POST",
+                                                         href: URL(string: "https://example.com")!,
+                                                         accepts: .formEncoded,
+                                                         parameters: [:])
+        let userAgent = request.httpHeaders["User-Agent"]
+        XCTAssertNotNil(userAgent)
+
+        let match = regexMatch(in: userAgent)
+        XCTAssertNotNil(match)
+    }
+
+    func testRemediationRequest() {
+        let request = IDXClient.APIVersion1.RemediationRequest(method: "POST",
+                                                               href: URL(string: "https://example.com")!,
+                                                               accepts: .formEncoded,
+                                                               parameters: [:])
+        let userAgent = request.httpHeaders["User-Agent"]
+        XCTAssertNotNil(userAgent)
+
+        let match = regexMatch(in: userAgent)
+        XCTAssertNotNil(match)
+    }
+}

--- a/okta-idx.xcodeproj/project.pbxproj
+++ b/okta-idx.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		960CD20825D5B02600523192 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960CD20725D5B02600523192 /* UserAgent.swift */; };
+		960CD20E25D5B77A00523192 /* UserAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960CD20D25D5B77A00523192 /* UserAgentTests.swift */; };
+		960CD21225D5BC2D00523192 /* URLSessionAuditTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960CD21125D5BC2D00523192 /* URLSessionAuditTests.swift */; };
 		960F853F25D4988000CAB52A /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = 960F853E25D4988000CAB52A /* Resources */; };
 		960F854525D4A13B00CAB52A /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960F854425D4A13B00CAB52A /* Bundle+Extensions.swift */; };
 		9617090F25AD109C000E9552 /* IDXVersion+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9617090E25AD109C000E9552 /* IDXVersion+Extension.swift */; };
@@ -68,6 +71,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		960CD20725D5B02600523192 /* UserAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
+		960CD20D25D5B77A00523192 /* UserAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentTests.swift; sourceTree = "<group>"; };
+		960CD21125D5BC2D00523192 /* URLSessionAuditTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionAuditTests.swift; sourceTree = "<group>"; };
 		960F853E25D4988000CAB52A /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Resources; sourceTree = "<group>"; };
 		960F854425D4A13B00CAB52A /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
 		9617090E25AD109C000E9552 /* IDXVersion+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IDXVersion+Extension.swift"; sourceTree = "<group>"; };
@@ -141,6 +147,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		960CD20625D5B01C00523192 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				960CD20725D5B02600523192 /* UserAgent.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
 		9617090B25AD104E000E9552 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -234,6 +248,8 @@
 				96A21F3125C0A5D7006C7BBB /* IDXRelatesToParserTests.swift */,
 				96549E2125C1FAF8007FCF29 /* IDXExtractFormValueTests.swift */,
 				962C3BD025C33EE70066987C /* IDXRemediationParameterTests.swift */,
+				960CD20D25D5B77A00523192 /* UserAgentTests.swift */,
+				960CD21125D5BC2D00523192 /* URLSessionAuditTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -290,6 +306,7 @@
 		96F8F2582582E93B00DA2701 /* Version1 */ = {
 			isa = PBXGroup;
 			children = (
+				960CD20625D5B01C00523192 /* Utilities */,
 				96F8B33D25BB445100DAECDC /* Debugging */,
 				961BE443258411B200DCE8AC /* Extensions */,
 				96F8F2592582E94A00DA2701 /* Requests */,
@@ -445,6 +462,7 @@
 				96F8F26C2582E9C900DA2701 /* IntrospectRequest.swift in Sources */,
 				961BE43E258406EC00DCE8AC /* PKCEExtensions.swift in Sources */,
 				961BE43A2583F8E900DCE8AC /* RequestHTTPHeaders.swift in Sources */,
+				960CD20825D5B02600523192 /* UserAgent.swift in Sources */,
 				96F8F26B2582E9C900DA2701 /* TokenRequest.swift in Sources */,
 				96F5417D258A843300D3995F /* IDXClient+V1ResponseConstructors.swift in Sources */,
 				966A1E80258BEADB00864DB7 /* IDXClientError+Extensions.swift in Sources */,
@@ -467,11 +485,13 @@
 				96F8F2302582C33A00DA2701 /* IDXClientAPIMock.swift in Sources */,
 				96DCDCEC25882263009487CB /* IDXClientAPIVersion1Tests.swift in Sources */,
 				96F8F22B2582C2DE00DA2701 /* IDXClientTests.swift in Sources */,
+				960CD20E25D5B77A00523192 /* UserAgentTests.swift in Sources */,
 				96437C2825CB266B00ED7E11 /* IDXResponseEqualityTests.swift in Sources */,
 				964A44B2259A90BE002CB250 /* IDXClientErrorTests.swift in Sources */,
 				96C584EE258ACEB200E79975 /* JSONValueTests.swift in Sources */,
 				961BE4272583E73300DCE8AC /* IDXClientRequestTests.swift in Sources */,
 				961BE42F2583EC6300DCE8AC /* TestExtensions.swift in Sources */,
+				960CD21225D5BC2D00523192 /* URLSessionAuditTests.swift in Sources */,
 				964A44E1259D3331002CB250 /* IDXClientV1ResponseTests.swift in Sources */,
 				96F8F1C125804A0C00DA2701 /* IDXClientVersionTests.swift in Sources */,
 				964A44BE259BB8FC002CB250 /* IDXAcceptTypeTests.swift in Sources */,


### PR DESCRIPTION
I would normally separate these into 2 different PRs, but I'm wanting to get this finished off as quickly as possible, so I want to avoid unnecessary overhead.