### PR TITLE
Make form value a protocol to avoid casting to AnyObject, and added a suite of unit tests to OktaIdxAuth

### DIFF
--- a/OktaIdxExample/OktaIdxExample/Signin/View Controllers/IDXRemediationTableViewController.swift
+++ b/OktaIdxExample/OktaIdxExample/Signin/View Controllers/IDXRemediationTableViewController.swift
@@ -281,7 +281,7 @@ extension Signin.Row {
                 cell.textField.text = field.value as? String
                 cell.textField.accessibilityIdentifier = "\(fieldName).field"
                 cell.update = { value in
-                    field.value = value as AnyObject
+                    field.value = value
                 }
             }
             
@@ -293,7 +293,7 @@ extension Signin.Row {
                 cell.fieldLabel.accessibilityIdentifier = "\(fieldName).label"
                 cell.switchView.isOn = field.value as? Bool ?? false
                 cell.update = { (value) in
-                    field.value = value as AnyObject
+                    field.value = value
                 }
             }
             

--- a/Sources/OktaIdx/Extensions/IDXFormValue.swift
+++ b/Sources/OktaIdx/Extensions/IDXFormValue.swift
@@ -1,0 +1,83 @@
+//
+// Copyright (c) 2021, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+
+/// Defines the types of properties that can be assigned to an `IDXClient.Remediation.Form.Field` value.
+public protocol IDXFormValue {
+}
+
+extension String : IDXFormValue {
+}
+
+extension Bool : IDXFormValue {
+}
+
+extension Double : IDXFormValue {
+}
+
+extension Int : IDXFormValue {
+}
+
+extension UInt : IDXFormValue {
+}
+
+extension Int8 : IDXFormValue {
+}
+
+extension UInt8 : IDXFormValue {
+}
+
+extension Int16 : IDXFormValue {
+}
+
+extension UInt16 : IDXFormValue {
+}
+
+extension Int32 : IDXFormValue {
+}
+
+extension UInt32 : IDXFormValue {
+}
+
+extension Int64 : IDXFormValue {
+}
+
+extension UInt64 : IDXFormValue {
+}
+
+extension Float : IDXFormValue {
+}
+
+extension Array : IDXFormValue where Element == IDXFormValue {
+}
+
+extension Dictionary : IDXFormValue {
+}
+
+@nonobjc extension NSString : IDXFormValue {
+}
+
+@nonobjc extension NSDate : IDXFormValue {
+}
+
+@nonobjc extension NSData : IDXFormValue {
+}
+
+@nonobjc extension NSNumber : IDXFormValue {
+}
+
+@nonobjc extension NSArray : IDXFormValue {
+}
+
+@nonobjc extension NSDictionary : IDXFormValue {
+}

--- a/Sources/OktaIdx/IDXFormField.swift
+++ b/Sources/OktaIdx/IDXFormField.swift
@@ -30,7 +30,15 @@ extension IDXClient.Remediation.Form {
         @objc public let type: String?
         
         /// The value to send, if a default is provided from the Identity Engine.
-        @objc public var value: AnyObject? {
+        @nonobjc public var value: IDXFormValue? {
+            get { _value as? IDXFormValue }
+            set {
+                guard isMutable else { return }
+                _value = newValue as AnyObject
+            }
+        }
+        
+        @objc(value) public var objcValue: AnyObject? {
             get { _value }
             set {
                 guard isMutable else { return }

--- a/Sources/OktaIdx/IDXRemediation.swift
+++ b/Sources/OktaIdx/IDXRemediation.swift
@@ -69,8 +69,8 @@ extension IDXClient {
                       href: URL,
                       accepts: String?,
                       form: Form,
-                      refresh: TimeInterval?,
-                      relatesTo: [String]?)
+                      refresh: TimeInterval? = nil,
+                      relatesTo: [String]? = nil)
         {
             self.client = client
             self.name = name

--- a/Sources/OktaIdx/IDXResponse.swift
+++ b/Sources/OktaIdx/IDXResponse.swift
@@ -15,7 +15,7 @@ import Foundation
 extension IDXClient {
     /// Describes the response from an Okta Identity Engine workflow stage. This is used to determine the current state of the workflow, the set of available remediation steps to proceed through the workflow, actions that can be performed, and other information relevant to the authentication of a user.
     @objc(IDXResponse)
-    public final class Response: NSObject {
+    public class Response: NSObject {
         /// The date at which this stage of the workflow expires, after which the authentication process should be restarted.
         @objc public let expiresAt: Date?
         

--- a/Sources/OktaIdx/Internal/Extensions/IDXClient+Extension.swift
+++ b/Sources/OktaIdx/Internal/Extensions/IDXClient+Extension.swift
@@ -13,13 +13,13 @@
 import Foundation
 
 extension IDXClient: IDXClientAPI {
-    func proceed(remediation option: Remediation, completion: ResponseResult?) {
+    public func proceed(remediation option: Remediation, completion: ResponseResult?) {
         api.proceed(remediation: option) { (response, error) in
             self.handleResponse(response, error: error, completion: completion)
         }
     }
 
-    func exchangeCode(using remediation: Remediation, completion: TokenResult?) {
+    public func exchangeCode(using remediation: Remediation, completion: TokenResult?) {
         api.exchangeCode(using: remediation) { (token, error) in
             self.handleResponse(token, error: error, completion: completion)
         }

--- a/Sources/OktaIdx/Internal/Implementations/IDXClientAPIImpl.swift
+++ b/Sources/OktaIdx/Internal/Implementations/IDXClientAPIImpl.swift
@@ -13,8 +13,9 @@
 import Foundation
 
 /// Internal protocol that defines the interface for the public IDXClient
-protocol IDXClientAPI: class {
+public protocol IDXClientAPI: class {
     var context: IDXClient.Context { get }
+    func resume(completion: IDXClient.ResponseResult?)
     func proceed(remediation option: IDXClient.Remediation,
                  completion: IDXClient.ResponseResult?)
 

--- a/Sources/OktaIdx/Internal/Implementations/Version1/IDXClientAPIv1.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/IDXClientAPIv1.swift
@@ -197,9 +197,9 @@ extension IDXClient.APIVersion1: IDXClientAPIImpl {
             return
         }
 
-        remediation.form["client_id"]?.value = configuration.clientId as AnyObject
-        remediation.form["client_secret"]?.value = configuration.clientSecret as AnyObject
-        remediation.form["code_verifier"]?.value = context.codeVerifier as AnyObject
+        remediation.form["client_id"]?.value = configuration.clientId
+        remediation.form["client_secret"]?.value = configuration.clientSecret
+        remediation.form["code_verifier"]?.value = context.codeVerifier
 
         let request: TokenRequest
         do {

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Responses/IDXClient+V1ResponseConstructors.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Responses/IDXClient+V1ResponseConstructors.swift
@@ -105,7 +105,7 @@ extension V1.Response {
         }
         
         if let authenticators = authenticatorEnrollments?.value,
-           authenticators.count > 0
+           !authenticators.isEmpty
         {
             for index in 0 ... authenticators.count - 1 {
                 allAuthenticators.append(.init(jsonPath: "$.authenticatorEnrollments.value[\(index)]",
@@ -114,7 +114,7 @@ extension V1.Response {
         }
         
         if let authenticators = authenticators?.value,
-           authenticators.count > 0
+           !authenticators.isEmpty
         {
             for index in 0 ... authenticators.count - 1 {
                 allAuthenticators.append(.init(jsonPath: "$.authenticators.value[\(index)]",

--- a/Sources/OktaIdxAuth/Internal/Requests/Authenticate.swift
+++ b/Sources/OktaIdxAuth/Internal/Requests/Authenticate.swift
@@ -28,7 +28,7 @@ extension OktaIdxAuth.Implementation.Request {
             super.init(completion: completion)
         }
 
-        func send(to implementation: Implementation,
+        func send(to implementation: OktaIdxAuthImplementation,
                   from response: IDXClient.Response? = nil)
         {
             if let selectIdentify = response?.remediations[.selectIdentify] {
@@ -52,7 +52,7 @@ extension OktaIdxAuth.Implementation.Request {
             }
         }
         
-        override func needsAdditionalRemediation(using response: IDXClient.Response?, from implementation: Implementation) {
+        override func needsAdditionalRemediation(using response: IDXClient.Response?, from implementation: OktaIdxAuthImplementation) {
             guard let completion = completion else {
                 fatalError(.unexpectedTransitiveRequest)
                 return
@@ -68,7 +68,7 @@ extension OktaIdxAuth.Implementation.Request {
             }
         }
         
-        override func hasError(implementation: Implementation,
+        override func hasError(implementation: OktaIdxAuthImplementation,
                                in response: IDXClient.Response) -> Bool
         {
             if let message = response.messages.message(for: "identifier") {

--- a/Sources/OktaIdxAuth/Internal/Requests/ChangePassword.swift
+++ b/Sources/OktaIdxAuth/Internal/Requests/ChangePassword.swift
@@ -25,7 +25,7 @@ extension OktaIdxAuth.Implementation.Request {
             super.init(completion: completion)
         }
 
-        func send(to implementation: OktaIdxAuth.Implementation,
+        func send(to implementation: OktaIdxAuthImplementation,
                   from response: IDXClient.Response? = nil)
         {
             if let reenroll = response?.remediations[.reenrollAuthenticator] {
@@ -39,7 +39,7 @@ extension OktaIdxAuth.Implementation.Request {
             }
         }
         
-        override func hasError(implementation: Implementation,
+        override func hasError(implementation: OktaIdxAuthImplementation,
                                in response: IDXClient.Response) -> Bool
         {
             if let message = response.remediations[.reenrollAuthenticator]?.messages.message(for: "passcode") {

--- a/Sources/OktaIdxAuth/Internal/Requests/EnrollAuthenticator.swift
+++ b/Sources/OktaIdxAuth/Internal/Requests/EnrollAuthenticator.swift
@@ -28,7 +28,7 @@ extension OktaIdxAuth.Implementation.Request {
             super.init(completion: completion)
         }
 
-        func send(to implementation: OktaIdxAuth.Implementation,
+        func send(to implementation: OktaIdxAuthImplementation,
                   from response: IDXClient.Response? = nil)
         {
             let remediationOption = (response != nil ? response?.remediations[.enrollAuthenticator] : authenticator.remediation)

--- a/Sources/OktaIdxAuth/Internal/Requests/RecoverPassword.swift
+++ b/Sources/OktaIdxAuth/Internal/Requests/RecoverPassword.swift
@@ -23,7 +23,7 @@ extension OktaIdxAuth.Implementation.Request {
             super.init(completion: completion)
         }
         
-        func send(to implementation: OktaIdxAuth.Implementation, from response: IDXClient.Response? = nil) {
+        func send(to implementation: OktaIdxAuthImplementation, from response: IDXClient.Response? = nil) {
             
         }
     }

--- a/Sources/OktaIdxAuth/Internal/Requests/Register.swift
+++ b/Sources/OktaIdxAuth/Internal/Requests/Register.swift
@@ -31,7 +31,7 @@ extension OktaIdxAuth.Implementation.Request {
             super.init(completion: completion)
         }
 
-        func send(to implementation: Implementation,
+        func send(to implementation: OktaIdxAuthImplementation,
                   from response: IDXClient.Response? = nil)
         {
             if let selectEnrollProfile = response?.remediations[.selectEnrollProfile] {

--- a/Sources/OktaIdxAuth/Internal/Requests/SelectAuthenticator.swift
+++ b/Sources/OktaIdxAuth/Internal/Requests/SelectAuthenticator.swift
@@ -28,7 +28,7 @@ extension OktaIdxAuth.Implementation.Request {
             super.init(completion: completion)
         }
 
-        func send(to implementation: OktaIdxAuth.Implementation,
+        func send(to implementation: OktaIdxAuthImplementation,
                   from response: IDXClient.Response? = nil)
         {
             var selectRemediation: IDXClient.Remediation!

--- a/Sources/OktaIdxAuth/Internal/Requests/SocialAuth.swift
+++ b/Sources/OktaIdxAuth/Internal/Requests/SocialAuth.swift
@@ -28,7 +28,7 @@ extension OktaIdxAuth.Implementation.Request {
             return true
         }
         
-        final func send(to implementation: OktaIdxAuth.Implementation, from response: IDXClient.Response? = nil) {
+        final func send(to implementation: OktaIdxAuthImplementation, from response: IDXClient.Response? = nil) {
             guard let remediation = response?.remediations[.redirectIdp] as? IDXClient.Remediation.SocialAuth,
                   let redirectUri = implementation.configuration?.redirectUri,
                   let scheme = URL(string: redirectUri)?.scheme
@@ -43,7 +43,7 @@ extension OktaIdxAuth.Implementation.Request {
                     return
                 }
                 
-                implementation.client { (client) in
+                implementation.client(reset: false) { (client) in
                     let result = client.redirectResult(for: callbackURL)
                     
                     switch result {

--- a/Sources/OktaIdxAuth/Internal/Requests/VerifyAuthenticator.swift
+++ b/Sources/OktaIdxAuth/Internal/Requests/VerifyAuthenticator.swift
@@ -28,7 +28,7 @@ extension OktaIdxAuth.Implementation.Request {
             super.init(completion: completion)
         }
 
-        func send(to implementation: OktaIdxAuth.Implementation,
+        func send(to implementation: OktaIdxAuthImplementation,
                   from response: IDXClient.Response? = nil)
         {
             if let response = response,

--- a/Sources/OktaIdxAuth/OktaIdxAuth.swift
+++ b/Sources/OktaIdxAuth/OktaIdxAuth.swift
@@ -60,6 +60,7 @@ import AuthenticationServices
         self.init(with: OktaIdxAuth.Implementation(with: context, queue: queue),
                   queue: queue,
                   completion: completion)
+        self.context = context
     }
     
     /// The context object created as a part of the authentication process; can be serialized for later use.
@@ -264,7 +265,6 @@ import AuthenticationServices
             }
         }
     }
-
 
     @objc(OktaIdxAuthSocialOptions)
     @available(OSX 10.15, *)

--- a/Tests/OktaIdxAuthTests/AuthenticateTests.swift
+++ b/Tests/OktaIdxAuthTests/AuthenticateTests.swift
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2021, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+@testable import OktaIdx
+@testable import OktaIdxAuth
+
+class AuthenticateTests: XCTestCase {
+    private typealias Authenticate = OktaIdxAuth.Implementation.Request<OktaIdxAuth.Response>.Authenticate
+    private typealias TestResponse = IDXClient.Response.Test
+    var api: OktaIdxAuthImplementationMock!
+    
+    override func setUpWithError() throws {
+        let context = IDXClient.Context(configuration: .init(issuer: "issuer",
+                                                             clientId: "clientId",
+                                                             clientSecret: "clientSecret",
+                                                             scopes: ["all"],
+                                                             redirectUri: "redirect:/uri"),
+                                        state: "state",
+                                        interactionHandle: "foo",
+                                        codeVerifier: "bar")
+        api = OktaIdxAuthImplementationMock(client: IDXClientAPIMock(context: context))
+        
+        try super.setUpWithError()
+    }
+    
+    func testSuccess() throws {
+        api.expect(function: "succeeded(with:completion:)", arguments: [
+            "token": IDXClient.Token.success
+        ])
+
+        let expect = expectation(description: "Completion")
+        let request = Authenticate(username: "trillian@earth.gov", password: "password") { (token, error) in
+            XCTAssertNotNil(token)
+            XCTAssertNil(error)
+            expect.fulfill()
+        }
+        
+        request.send(to: api, from: TestResponse(client: api.client, with: [ .identify, .cancel ])
+                        .when(.identify, send: TestResponse(client: api.client, with: [ .challengeAuthenticator(state: .normal), .cancel ])
+                                .when(.challengeAuthenticator, send: TestResponse(client: api.client, with: [ .successWithInteractionCode ]))))
+        
+        wait(for: [expect], timeout: 1)
+    }
+}

--- a/Tests/OktaIdxAuthTests/OktaIdxAuthTests.swift
+++ b/Tests/OktaIdxAuthTests/OktaIdxAuthTests.swift
@@ -28,19 +28,205 @@ class OktaIdxAuthTests: XCTestCase {
                                     state: "state",
                                     interactionHandle: "foo",
                                     codeVerifier: "bar")
-    var client: OktaIdxAuth!
     var api: OktaIdxAuthImplementationMock!
-    var result: (IDXClient.Token?, Error?)?
-    
+    var idxResponse: IDXClient.Response!
+    var idxRemediation: IDXClient.Remediation!
+    var idxClient = IDXClientAPIMock(context: .init(configuration: .init(issuer: "issuer",
+                                                                         clientId: "clientId",
+                                                                         clientSecret: "clientSecret",
+                                                                         scopes: ["all"],
+                                                                         redirectUri: "redirect://uri"),
+                                                    state: "stateHandle",
+                                                    interactionHandle: "interactionHandle",
+                                                    codeVerifier: "codeVerifier"))
+
     override func setUpWithError() throws {
-        api = OktaIdxAuthImplementationMock()
-        client = OktaIdxAuth.init(with: api, queue: .main, completion: { (token, error) in
-            self.result = (token, error)
-        })
+        api = OktaIdxAuthImplementationMock(client: IDXClientAPIMock(context: context))
+
+        idxRemediation = IDXClient.Remediation(client: idxClient,
+                                                     name: "cancel",
+                                                     method: "GET",
+                                                     href: URL(string: "some://url")!,
+                                                     accepts: "application/json",
+                                                     form: IDXClient.Remediation.Form(fields: [
+                                                        IDXClient.Remediation.Form.Field(name: "foo",
+                                                                                         visible: false,
+                                                                                         mutable: true,
+                                                                                         required: false,
+                                                                                         secret: false)
+                                                     ])!,
+                                                     refresh: nil,
+                                                     relatesTo: nil)
+
+        idxResponse = IDXClient.Response(client: idxClient,
+                                          expiresAt: Date(),
+                                          intent: .login,
+                                          authenticators: .init(authenticators: nil),
+                                          remediations: .init(remediations: [idxRemediation]),
+                                          successRemediationOption: nil,
+                                          messages: .init(messages: nil),
+                                          app: nil,
+                                          user: nil)
     }
 
+    func wait(timeout: TimeInterval = 1,
+              _ block: @escaping (XCTestExpectation) -> Void)
+    {
+        let expect = expectation(description: "authenticate")
+        block(expect)
+        wait(for: [ expect ], timeout: 1)
+    }
+    
     func testConstructors() {
-        XCTAssertNotNil(api)
-        // TODO: More tests to come
+        var client = OktaIdxAuth(with: context) { (_, _) in}
+        XCTAssertNotNil(client)
+        XCTAssertEqual(client.context, context)
+        
+        client = OktaIdxAuth(issuer: "issuer", clientId: "clientId", clientSecret: "clientSecret", scopes: ["all"], redirectUri: "redirect:/uri", completion: { (_, _) in})
+        XCTAssertNotNil(client)
+        XCTAssertNil(client.context)
+    }
+    
+    func testClientApiDelegation() throws {
+        let client = OktaIdxAuth.init(with: api, queue: .main) { _,_ in }
+        var call: MockBase.RecordedCall?
+
+        // authenticate
+        wait { expectation in
+            client.authenticate(username: "zaphod@galaxy.gov", password: "password") { _,_ in
+                expectation.fulfill()
+            }
+        }
+        call = api.recordedCalls.last
+        XCTAssertEqual(call?.function, "authenticate(username:password:completion:)")
+        XCTAssertEqual(call?.arguments?.count, 2)
+        XCTAssertEqual(call?.arguments?["username"] as? String, "zaphod@galaxy.gov")
+        XCTAssertEqual(call?.arguments?["password"] as? String, "password")
+        api.reset()
+
+        // socialAuth
+        wait { expectation in
+            client.socialAuth { _,_ in
+                expectation.fulfill()
+            }
+        }
+        call = api.recordedCalls.last
+        XCTAssertEqual(call?.function, "socialAuth(completion:)")
+        XCTAssertEqual(call?.arguments?.count, 0)
+        api.reset()
+
+        // recoverPassword
+        wait { expectation in
+            client.recoverPassword(username: "adent@earth.org", authenticator: .email) { _,_ in
+                expectation.fulfill()
+            }
+        }
+        call = api.recordedCalls.last
+        XCTAssertEqual(call?.function, "recoverPassword(username:authenticator:completion:)")
+        XCTAssertEqual(call?.arguments?.count, 2)
+        XCTAssertEqual(call?.arguments?["username"] as? String, "adent@earth.org")
+        XCTAssertEqual(call?.arguments?["authenticator"] as? OktaIdxAuth.Authenticator.AuthenticatorType,
+                       .email)
+        api.reset()
+
+        // register
+        wait { expectation in
+            client.register(firstName: "Arthur", lastName: "Dent", email: "adent@earth.org") { _,_ in
+                expectation.fulfill()
+            }
+        }
+        call = api.recordedCalls.last
+        XCTAssertEqual(call?.function, "register(firstName:lastName:email:completion:)")
+        XCTAssertEqual(call?.arguments?.count, 3)
+        XCTAssertEqual(call?.arguments?["firstName"] as? String, "Arthur")
+        XCTAssertEqual(call?.arguments?["lastName"] as? String, "Dent")
+        XCTAssertEqual(call?.arguments?["email"] as? String, "adent@earth.org")
+        api.reset()
+
+        // revokeTokens
+        wait { expectation in
+            client.revokeTokens(token: "tokenId", type: .accessAndRefreshToken) { _,_ in
+                expectation.fulfill()
+            }
+        }
+        call = api.recordedCalls.last
+        XCTAssertEqual(call?.function, "revokeTokens(token:type:completion:)")
+        XCTAssertEqual(call?.arguments?.count, 2)
+        XCTAssertEqual(call?.arguments?["token"] as? String, "tokenId")
+        XCTAssertEqual(call?.arguments?["type"] as? OktaIdxAuth.TokenType,
+                       .accessAndRefreshToken)
+        api.reset()
+    }
+    
+    func testResponseApiDelegation() throws {
+        let response = OktaIdxAuth.Response(with: api,
+                                            status: .success,
+                                            availableAuthenticators: [],
+                                            detailedResponse: idxResponse,
+                                            authenticator: nil)
+        var call: MockBase.RecordedCall?
+
+        // changePassword
+        wait { expectation in
+            response.change(password: "newPassword") { _,_ in
+                expectation.fulfill()
+            }
+        }
+        call = api.recordedCalls.last
+        XCTAssertEqual(call?.function, "changePassword(_:from:completion:)")
+        XCTAssertEqual(call?.arguments?.count, 2)
+        XCTAssertEqual(call?.arguments?["password"] as? String, "newPassword")
+        XCTAssertEqual(call?.arguments?["response"] as? OktaIdxAuth.Response, response)
+        api.reset()
+
+        // select
+        wait { expectation in
+            response.select(authenticator: .email) { _,_ in
+                expectation.fulfill()
+            }
+        }
+        call = api.recordedCalls.last
+        XCTAssertEqual(call?.function, "select(authenticator:from:completion:)")
+        XCTAssertEqual(call?.arguments?.count, 2)
+        XCTAssertEqual(call?.arguments?["authenticator"] as? OktaIdxAuth.Authenticator.AuthenticatorType, .email)
+        XCTAssertEqual(call?.arguments?["response"] as? IDXClient.Response, idxResponse)
+        api.reset()
+    }
+
+    func testAuthenticatorApiDelegation() throws {
+        let authenticator = OktaIdxAuth.Authenticator(implementation: api,
+                                                      remediation: idxRemediation,
+                                                      type: .email)
+        var call: MockBase.RecordedCall?
+
+        // verify
+        wait { expectation in
+            authenticator.verify(with: "123456") { _,_ in
+                expectation.fulfill()
+            }
+        }
+        call = api.recordedCalls.last
+        XCTAssertEqual(call?.function, "verify(authenticator:with:completion:)")
+        XCTAssertEqual(call?.arguments?.count, 2)
+        XCTAssertEqual(call?.arguments?["authenticator"] as? OktaIdxAuth.Authenticator, authenticator)
+        XCTAssertEqual(call?.arguments?["result"] as? [String:String], [
+            "credentials.passcode": "123456"
+        ])
+        api.reset()
+
+        // enroll
+        wait { expectation in
+            authenticator.enroll(using: ["code": "123456"]) { _,_ in
+                expectation.fulfill()
+            }
+        }
+        call = api.recordedCalls.last
+        XCTAssertEqual(call?.function, "enroll(authenticator:with:completion:)")
+        XCTAssertEqual(call?.arguments?.count, 2)
+        XCTAssertEqual(call?.arguments?["authenticator"] as? OktaIdxAuth.Authenticator, authenticator)
+        XCTAssertEqual(call?.arguments?["result"] as? [String:String], [
+            "code": "123456"
+        ])
+        api.reset()
     }
 }

--- a/Tests/OktaIdxTests/IDXExtractFormValueTests.swift
+++ b/Tests/OktaIdxTests/IDXExtractFormValueTests.swift
@@ -45,7 +45,7 @@ class IDXExtractFormValueTests: XCTestCase {
                       required: true,
                       secret: false)
         ]))
-        form["identifier"]?.value = "me@example.com" as AnyObject
+        form["identifier"]?.value = "me@example.com"
         let result = try form.formValues()
         XCTAssertEqual(result as? [String:String], [
             "stateHandle": "abcEasyAs123",
@@ -76,7 +76,7 @@ class IDXExtractFormValueTests: XCTestCase {
                                   secret: true)
                       ]))
         ]))
-        form["credentials.passcode"]?.value = "password" as AnyObject
+        form["credentials.passcode"]?.value = "password"
         
         let result = try form.formValues()
         XCTAssertEqual(result["stateHandle"] as? String, "abcEasyAs123")
@@ -184,7 +184,7 @@ class IDXExtractFormValueTests: XCTestCase {
         ]))
         form["authenticator"]?.selectedOption = nestedForm
         nestedForm.form?["methodType"]?.selectedOption = smsOption
-        nestedForm.form?["phoneNumber"]?.value = "+1 123-555-1234" as AnyObject
+        nestedForm.form?["phoneNumber"]?.value = "+1 123-555-1234"
         
         let result = try form.formValues()
         XCTAssertEqual(result["stateHandle"] as? String, "abcEasyAs123")

--- a/Tests/OktaIdxTests/IDXFormValueTests.swift
+++ b/Tests/OktaIdxTests/IDXFormValueTests.swift
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2021, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import XCTest
+@testable import OktaIdx
+
+class IDXFormValueTests: XCTestCase {
+    func testProtocolConformance() throws {
+        let field = IDXClient.Remediation.Form.Field(name: "foo",
+                                                     value: "StateHandle" as AnyObject,
+                                                     visible: true,
+                                                     mutable: true,
+                                                     required: true,
+                                                     secret: false)
+//        XCTAssertEqual(field.value as Equatable, "StateHandle")
+    }
+}

--- a/Tests/OktaIdxTests/IDXRemediationParameterTests.swift
+++ b/Tests/OktaIdxTests/IDXRemediationParameterTests.swift
@@ -42,8 +42,8 @@ class IDXRemediationParameterTests: XCTestCase {
             return
         }
 
-        identifier.value = "test@example.com" as AnyObject
-        rememberMe.value = true as AnyObject
+        identifier.value = "test@example.com"
+        rememberMe.value = true
 
         let result = try remediationOption.form.formValues()
         XCTAssertEqual(result["stateHandle"] as? String, "ahc52KautBHCANs3ScZjLfRcxFjP_N5mqOTYouqHFP")
@@ -66,7 +66,7 @@ class IDXRemediationParameterTests: XCTestCase {
             return
         }
 
-        passcode.value = "password" as AnyObject
+        passcode.value = "password"
 
         let result = try remediationOption.form.formValues()
         XCTAssertEqual(result["stateHandle"] as? String, "ahc52KautBHCANs3ScZjLfRcxFjP_N5mqOTYouqHFP")
@@ -122,7 +122,7 @@ class IDXRemediationParameterTests: XCTestCase {
 
         authenticator.selectedOption = phoneOption
         methodType.selectedOption = smsType
-        phoneNumber.value = "5551234567" as AnyObject
+        phoneNumber.value = "5551234567"
 
         let result = try remediationOption.form.formValues()
         XCTAssertEqual(result["stateHandle"] as? String, "ahc52KautBHCANs3ScZjLfRcxFjP_N5mqOTYouqHFP")

--- a/Tests/OktaIdxTests/ScenarioTests.swift
+++ b/Tests/OktaIdxTests/ScenarioTests.swift
@@ -63,7 +63,7 @@ class ScenarioTests: XCTestCase {
                 XCTAssertEqual(remediation?.form[0].name, "identifier")
                 XCTAssertEqual(remediation?.form[1].name, "rememberMe")
                 XCTAssertEqual(remediation?.form.allFields[2].name, "stateHandle")
-                remediation?.form["identifier"]?.value = "user@example.com" as AnyObject
+                remediation?.form["identifier"]?.value = "user@example.com"
                 
                 remediation?.proceed { (response, error) in
                     XCTAssertNotNil(response)
@@ -80,7 +80,7 @@ class ScenarioTests: XCTestCase {
                     
                     let credentials = remediation?.form[0]
                     XCTAssertTrue(credentials?.isRequired ?? false)
-                    remediation?.form["credentials"]?.form?["passcode"]?.value = "password" as AnyObject
+                    remediation?.form["credentials"]?.form?["passcode"]?.value = "password"
 
                     remediation?.proceed { (response, error) in
                         XCTAssertNotNil(response)
@@ -136,8 +136,8 @@ class ScenarioTests: XCTestCase {
                 let stateHandleField = remediation?.form.allFields[2]
                 XCTAssertEqual(stateHandleField?.name, "stateHandle")
                 
-                identifierField?.value = "user@example.com" as AnyObject
-                rememberMeField?.value = false as AnyObject
+                identifierField?.value = "user@example.com"
+                rememberMeField?.value = false
                 
                 // Identify ourselves as the given user, which returns the identify-response
                 remediation?.proceed { (response, error) in
@@ -228,7 +228,7 @@ class ScenarioTests: XCTestCase {
                 let remediation = response?.remediations.first
                 XCTAssertEqual(remediation?.name, "identify")
                 
-                remediation?["identify"]?.value = "user@example.com" as AnyObject
+                remediation?["identify"]?.value = "user@example.com"
                 
                 remediation?.proceed { (response, error) in
                     XCTAssertNotNil(response)
@@ -258,7 +258,7 @@ class ScenarioTests: XCTestCase {
                         let related = remediation?.authenticators.first?.value
                         XCTAssertEqual(related, currentEnrollment)
                         
-                        remediation?.form["credentials.passcode"]?.value = "password" as AnyObject
+                        remediation?.form["credentials.passcode"]?.value = "password"
                         
                         remediation?.proceed { (response, error) in
                             XCTAssertNotNil(response)

--- a/Tests/TestCommon_OktaIdx/Mocks/IDXClientAPIMock.swift
+++ b/Tests/TestCommon_OktaIdx/Mocks/IDXClientAPIMock.swift
@@ -41,6 +41,13 @@ class IDXClientAPIMock: MockBase, IDXClientAPI {
         self.context = context
     }
     
+    func resume(completion: IDXClient.ResponseResult?) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [:]))
+        let result = response(for: #function)
+        completion?(result?["response"] as? IDXClient.Response, result?["error"] as? Error)
+    }
+    
     func proceed(remediation option: IDXClient.Remediation, completion: IDXClient.ResponseResult?) {
         recordedCalls.append(RecordedCall(function: #function,
                                           arguments: [

--- a/Tests/TestCommon_OktaIdxAuth/IDXResponse+TestFactory.swift
+++ b/Tests/TestCommon_OktaIdxAuth/IDXResponse+TestFactory.swift
@@ -1,0 +1,205 @@
+//
+// Copyright (c) 2021, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+@testable import OktaIdx
+
+extension IDXClient.Response {
+    enum Option {
+        case cancel
+        case selectIdentify
+        case identify
+        case challengeAuthenticator(state: ChallengeState)
+        case selectAuthenticatorAuthenticate(authenticators: [Authenticator])
+        case successWithInteractionCode
+        case skip
+        
+        enum ChallengeState {
+            case normal
+            case success
+            case passwordError
+        }
+        
+        enum Authenticator {
+            case email
+            case password
+            case phone
+        }
+    }
+    
+    
+    class Test: IDXClient.Response {
+        init(client: IDXClientAPI,
+             intent: IDXClient.Response.Intent = .login,
+             with options: [Option])
+        {
+            var authenticators = [IDXClient.Authenticator]()
+            var remediations = [IDXClient.Remediation]()
+            var successRemediation: IDXClient.Remediation?
+            var messages = [IDXClient.Message]()
+            
+            for option in options {
+                switch option {
+                case .cancel:
+                    remediations.append(IDXClient.Remediation.Test(client: client,
+                                                                   name: "cancel",
+                                                                   method: "POST",
+                                                                   href: URL(string: "https://example.com/idp/idx/cancel")!,
+                                                                   accepts: "application/ion+json; okta-version=1.0.0",
+                                                                   form: IDXClient.Remediation.Form([ .stateHandle ])))
+                case .selectIdentify: break
+                case .identify:
+                    remediations.append(IDXClient.Remediation.Test(client: client,
+                                                                   name: "identify",
+                                                                   method: "POST",
+                                                                   href: URL(string: "https://example.com/idp/idx/identify")!,
+                                                                   accepts: "application/ion+json; okta-version=1.0.0",
+                                                                   form: IDXClient.Remediation.Form([ .identifier, .rememberMe, .stateHandle ])))
+                case .challengeAuthenticator(state: let state):
+                    remediations.append(IDXClient.Remediation.Test(client: client,
+                                                                   name: "challenge-authenticator",
+                                                                   method: "POST",
+                                                                   href: URL(string: "https://example.com/idp/idx/identify")!,
+                                                                   accepts: "application/ion+json; okta-version=1.0.0",
+                                                                   form: IDXClient.Remediation.Form([ .identifier, .rememberMe, .stateHandle ])))
+                case .successWithInteractionCode:
+                    successRemediation = IDXClient.Remediation.Test(client: client,
+                                                                    name: "issue",
+                                                                    method: "POST",
+                                                                    href: URL(string: "https://example.com/oauth2/blahblah/v1/token")!,
+                                                                    accepts: "application/ion+json; okta-version=1.0.0",
+                                                                    form: IDXClient.Remediation.Form(fields: [
+                                                                        .init(name: "grant_type",
+                                                                              value: "interaction_code",
+                                                                              visible: false,
+                                                                              mutable: false,
+                                                                              required: true,
+                                                                              secret: false),
+                                                                        .init(name: "interaction_code",
+                                                                              value: "blahblahblah",
+                                                                              visible: false,
+                                                                              mutable: false,
+                                                                              required: true,
+                                                                              secret: false),
+                                                                        .init(name: "client_id",
+                                                                              value: "clientId",
+                                                                              visible: false,
+                                                                              mutable: false,
+                                                                              required: true,
+                                                                              secret: false),
+                                                                        .init(name: "client_secret",
+                                                                              visible: false,
+                                                                              mutable: false,
+                                                                              required: true,
+                                                                              secret: false),
+                                                                        .init(name: "code_verifier",
+                                                                              visible: false,
+                                                                              mutable: false,
+                                                                              required: true,
+                                                                              secret: false)
+                                                                    ])!)
+                    
+                case .selectAuthenticatorAuthenticate(authenticators: let authenticators): break
+                    
+                case .skip:
+                    remediations.append(IDXClient.Remediation.Test(client: client,
+                                                                   name: "skip",
+                                                                   method: "POST",
+                                                                   href: URL(string: "https://example.com/idp/idx/skip")!,
+                                                                   accepts: "application/ion+json; okta-version=1.0.0",
+                                                                   form: IDXClient.Remediation.Form([ .stateHandle ])))
+                }
+            }
+            
+            super.init(client: client,
+                       expiresAt: Date(),
+                       intent: intent,
+                       authenticators: .init(authenticators: authenticators),
+                       remediations: .init(remediations: remediations),
+                       successRemediationOption: successRemediation,
+                       messages: .init(messages: messages),
+                       app: nil,
+                       user: nil)
+        }
+        
+        func when(_ type: IDXClient.Remediation.RemediationType, send response: Test) -> Test {
+            guard let remediation = remediations[type] as? IDXClient.Remediation.Test else { return self }
+            remediation.proceedResponse = response
+            return self
+        }
+        
+        func when(_ type: IDXClient.Remediation.RemediationType, send error: Error) -> Test {
+            guard let remediation = remediations[type] as? IDXClient.Remediation.Test else { return self }
+            remediation.proceedError = error
+            return self
+        }
+    }
+}
+
+extension IDXClient.Remediation {
+    class Test: IDXClient.Remediation {
+        fileprivate var proceedResponse: IDXClient.Response.Test?
+        fileprivate var proceedError: Error?
+        
+        override func proceed(completion: IDXClient.ResponseResult?) {
+            completion?(proceedResponse, proceedError)
+        }
+    }
+}
+
+extension IDXClient.Remediation.Form {
+    convenience init(_ fields: [Field.TestField]) {
+        self.init(fields: fields.map { Field($0) })!
+    }
+}
+
+extension IDXClient.Token {
+    static let success = IDXClient.Token(accessToken: "access",
+                                         refreshToken: "refresh",
+                                         expiresIn: 3600,
+                                         idToken: nil,
+                                         scope: "all",
+                                         tokenType: "Bearer")
+}
+
+extension IDXClient.Remediation.Form.Field {
+    enum TestField {
+        case stateHandle, identifier, rememberMe
+    }
+    
+    convenience init(_ type: TestField) {
+        switch type {
+        case .stateHandle:
+            self.init(name: "stateHandle",
+                      value: "ABC_easy_as_123",
+                      visible: false,
+                      mutable: false,
+                      required: true,
+                      secret: false)
+        case .identifier:
+            self.init(name: "identifier",
+                  label: "Username",
+                  visible: true,
+                  mutable: true,
+                  required: false,
+                  secret: false)
+        case .rememberMe:
+            self.init(name: "rememberMe",
+                      label: "Remember this device",
+                      type: "boolean",
+                      visible: true,
+                      mutable: true,
+                      required: false,
+                      secret: false)
+        }
+    }
+}

--- a/Tests/TestCommon_OktaIdxAuth/OktaIdxAuthImplementationMock.swift
+++ b/Tests/TestCommon_OktaIdxAuth/OktaIdxAuthImplementationMock.swift
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2021, Okta, Inc. and/or its affiliates. All rights reserved.
+ * The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+ *
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import Foundation
+@testable import OktaIdx
+@testable import OktaIdxAuth
+
+#if SWIFT_PACKAGE
+@testable import TestCommon_OktaIdx
+#endif
+
+class OktaIdxAuthImplementationMock: MockBase, OktaIdxAuthImplementation {
+    var client: IDXClientAPI
+    var configuration: IDXClient.Configuration?
+    
+    weak var delegate: OktaIdxAuthImplementationDelegate?
+    
+    var queue: DispatchQueue = .main
+
+    required init(client: IDXClientAPI) {
+        self.client = client
+        
+        super.init()
+    }
+    
+    func client(reset: Bool, completion: @escaping (IDXClientAPI) -> Void) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "reset": reset as Bool
+                                          ]))
+        let result = self.response(for: #function)
+        completion(client)
+    }
+    
+    func succeeded(with response: IDXClient.Response, completion: @escaping (IDXClient.Token?, Error?) -> Void) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "response": response as Any
+                                          ]))
+        let result = self.response(for: #function)
+        completion(result?["token"] as? IDXClient.Token, result?["error"] as? Error)
+
+    }
+    
+    func fail(with error: Error) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "error": error as Any
+                                          ]))
+    }
+    
+    func authenticate(username: String, password: String?, completion: OktaIdxAuth.ResponseResult<OktaIdxAuth.Response>?) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "username": username as Any,
+                                            "password": password as Any
+                                          ]))
+        let result = self.response(for: #function)
+        completion?(result?["response"] as? OktaIdxAuth.Response, result?["error"] as? Error)
+    }
+    
+    @available(OSX 10.15, *)
+    @available(iOSApplicationExtension 12.0, *)
+    func socialAuth(with options: OktaIdxAuth.SocialOptions, completion: OktaIdxAuth.ResponseResult<OktaIdxAuth.Response>?) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "options": options as Any
+                                          ]))
+        let result = self.response(for: #function)
+        completion?(result?["response"] as? OktaIdxAuth.Response, result?["error"] as? Error)
+    }
+    
+    @available(OSX 10.15, *)
+    @available(iOSApplicationExtension 12.0, *)
+    func socialAuth(completion: OktaIdxAuth.ResponseResult<OktaIdxAuth.Response>?) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [:]))
+        let result = self.response(for: #function)
+        completion?(result?["response"] as? OktaIdxAuth.Response, result?["error"] as? Error)
+    }
+    
+    func changePassword(_ password: String, from response: OktaIdxAuth.Response, completion: OktaIdxAuth.ResponseResult<OktaIdxAuth.Response>?) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "password": password as Any,
+                                            "response": response as Any
+                                          ]))
+        let result = self.response(for: #function)
+        completion?(result?["response"] as? OktaIdxAuth.Response, result?["error"] as? Error)
+    }
+    
+    func recoverPassword(username: String, authenticator type: OktaIdxAuth.Authenticator.AuthenticatorType, completion: OktaIdxAuth.ResponseResult<OktaIdxAuth.Response>?) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "username": username as Any,
+                                            "authenticator": type as Any
+                                          ]))
+        let result = self.response(for: #function)
+        completion?(result?["response"] as? OktaIdxAuth.Response, result?["error"] as? Error)
+    }
+    
+    func select(authenticator: OktaIdxAuth.Authenticator.AuthenticatorType, from idxResponse: IDXClient.Response, completion: @escaping OktaIdxAuth.ResponseResult<OktaIdxAuth.Response>) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "authenticator": authenticator as Any,
+                                            "response": idxResponse as Any
+                                          ]))
+        let result = self.response(for: #function)
+        completion(result?["response"] as? OktaIdxAuth.Response, result?["error"] as? Error)
+    }
+    
+    func verify(authenticator: OktaIdxAuth.Authenticator, with result: [String : String], completion: OktaIdxAuth.ResponseResult<OktaIdxAuth.Response>?) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "authenticator": authenticator as Any,
+                                            "result": result as Any
+                                          ]))
+        let result = self.response(for: #function)
+        completion?(result?["response"] as? OktaIdxAuth.Response, result?["error"] as? Error)
+    }
+    
+    func enroll(authenticator: OktaIdxAuth.Authenticator, with result: [String : String], completion: OktaIdxAuth.ResponseResult<OktaIdxAuth.Response>?) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "authenticator": authenticator as Any,
+                                            "result": result as Any
+                                          ]))
+        let result = self.response(for: #function)
+        completion?(result?["response"] as? OktaIdxAuth.Response, result?["error"] as? Error)
+    }
+    
+    func register(firstName: String, lastName: String, email: String, completion: OktaIdxAuth.ResponseResult<OktaIdxAuth.Response>?) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "firstName": firstName as Any,
+                                            "lastName": lastName as Any,
+                                            "email": email as Any
+                                          ]))
+        let result = self.response(for: #function)
+        completion?(result?["response"] as? OktaIdxAuth.Response, result?["error"] as? Error)
+    }
+    
+    func revokeTokens(token: String, type: OktaIdxAuth.TokenType, completion: OktaIdxAuth.ResponseResult<OktaIdxAuth.Response>?) {
+        recordedCalls.append(RecordedCall(function: #function,
+                                          arguments: [
+                                            "token": token as Any,
+                                            "type": type as Any
+                                          ]))
+        let result = self.response(for: #function)
+        completion?(result?["response"] as? OktaIdxAuth.Response, result?["error"] as? Error)
+    }
+}

--- a/okta-idx.xcodeproj/project.pbxproj
+++ b/okta-idx.xcodeproj/project.pbxproj
@@ -72,9 +72,13 @@
 		966A1E76258BDB1B00864DB7 /* URLSessionProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966A1E75258BDB1B00864DB7 /* URLSessionProtocolTests.swift */; };
 		966A1E80258BEADB00864DB7 /* IDXClientError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 966A1E7F258BEADB00864DB7 /* IDXClientError+Extensions.swift */; };
 		967102CA2587F93E00D5D85F /* URLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967102C92587F93D00D5D85F /* URLSessionMock.swift */; };
+		968CD886264C8D12003F0B44 /* IDXFormValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968CD885264C8D12003F0B44 /* IDXFormValue.swift */; };
+		968CD890264CA119003F0B44 /* IDXFormValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968CD88F264CA119003F0B44 /* IDXFormValueTests.swift */; };
 		969096BB264A0847003275E5 /* OktaIdxAuthImplementationMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969096BA264A0847003275E5 /* OktaIdxAuthImplementationMock.swift */; };
 		9692D5E9264378A200D30404 /* Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9692D5E7264378A200D30404 /* Register.swift */; };
 		9692D5EA264378A200D30404 /* EnrollAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9692D5E8264378A200D30404 /* EnrollAuthenticator.swift */; };
+		96A144E1264B3C8D002DCC4D /* AuthenticateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A144E0264B3C8D002DCC4D /* AuthenticateTests.swift */; };
+		96A144E6264B55C8002DCC4D /* IDXResponse+TestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A144E5264B55C8002DCC4D /* IDXResponse+TestFactory.swift */; };
 		96A1A2112645FA7A0088EF85 /* SelectAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A1A2102645FA7A0088EF85 /* SelectAuthenticator.swift */; };
 		96A21F3E25C1E4F0006C7BBB /* URLSessionAudit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A21F3D25C1E4F0006C7BBB /* URLSessionAudit.swift */; };
 		96A6EDBF2649EC21000D4C31 /* IDXResponse+AvailableAuthenticators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A6EDBE2649EC21000D4C31 /* IDXResponse+AvailableAuthenticators.swift */; };
@@ -224,9 +228,13 @@
 		966A1E75258BDB1B00864DB7 /* URLSessionProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionProtocolTests.swift; sourceTree = "<group>"; };
 		966A1E7F258BEADB00864DB7 /* IDXClientError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IDXClientError+Extensions.swift"; sourceTree = "<group>"; };
 		967102C92587F93D00D5D85F /* URLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
+		968CD885264C8D12003F0B44 /* IDXFormValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDXFormValue.swift; sourceTree = "<group>"; };
+		968CD88F264CA119003F0B44 /* IDXFormValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDXFormValueTests.swift; sourceTree = "<group>"; };
 		969096BA264A0847003275E5 /* OktaIdxAuthImplementationMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OktaIdxAuthImplementationMock.swift; sourceTree = "<group>"; };
 		9692D5E7264378A200D30404 /* Register.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Register.swift; sourceTree = "<group>"; };
 		9692D5E8264378A200D30404 /* EnrollAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnrollAuthenticator.swift; sourceTree = "<group>"; };
+		96A144E0264B3C8D002DCC4D /* AuthenticateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticateTests.swift; sourceTree = "<group>"; };
+		96A144E5264B55C8002DCC4D /* IDXResponse+TestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IDXResponse+TestFactory.swift"; sourceTree = "<group>"; };
 		96A1A2102645FA7A0088EF85 /* SelectAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectAuthenticator.swift; sourceTree = "<group>"; };
 		96A21F3D25C1E4F0006C7BBB /* URLSessionAudit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionAudit.swift; sourceTree = "<group>"; };
 		96A6EDBE2649EC21000D4C31 /* IDXResponse+AvailableAuthenticators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IDXResponse+AvailableAuthenticators.swift"; sourceTree = "<group>"; };
@@ -320,6 +328,7 @@
 				965D74C42641A41C0093FFD1 /* IDXConfiguration+Extensions.swift */,
 				9647740B263A41B00059EBC4 /* IDXContext+Extensions.swift */,
 				964773FD2638DE6B0059EBC4 /* IDXForm+Extension.swift */,
+				968CD885264C8D12003F0B44 /* IDXFormValue.swift */,
 				96477413263A425D0059EBC4 /* IDXMessage+Extensions.swift */,
 				965D74D62641C18E0093FFD1 /* IDXMessageCollection+Extension.swift */,
 				964773EB2638C5E40059EBC4 /* IDXRemediationCollection+Extension.swift */,
@@ -385,6 +394,7 @@
 			children = (
 				965C3B4A261F87B200EBD800 /* Info.plist */,
 				96AD28A5264A01ED00829BF7 /* OktaIdxAuthTests.swift */,
+				96A144E0264B3C8D002DCC4D /* AuthenticateTests.swift */,
 			);
 			path = OktaIdxAuthTests;
 			sourceTree = "<group>";
@@ -441,6 +451,7 @@
 				9291B40925E90FC500450BBE /* IDXRedirectTests.swift */,
 				960CD20D25D5B77A00523192 /* UserAgentTests.swift */,
 				960CD21125D5BC2D00523192 /* URLSessionAuditTests.swift */,
+				968CD88F264CA119003F0B44 /* IDXFormValueTests.swift */,
 			);
 			path = OktaIdxTests;
 			sourceTree = "<group>";
@@ -449,6 +460,7 @@
 			isa = PBXGroup;
 			children = (
 				969096BA264A0847003275E5 /* OktaIdxAuthImplementationMock.swift */,
+				96A144E5264B55C8002DCC4D /* IDXResponse+TestFactory.swift */,
 			);
 			path = TestCommon_OktaIdxAuth;
 			sourceTree = "<group>";
@@ -846,6 +858,8 @@
 				96AD28A1264A01D000829BF7 /* TestExtensions.swift in Sources */,
 				969096BB264A0847003275E5 /* OktaIdxAuthImplementationMock.swift in Sources */,
 				96AD289E264A01D000829BF7 /* Bundle+Extensions.swift in Sources */,
+				96A144E6264B55C8002DCC4D /* IDXResponse+TestFactory.swift in Sources */,
+				96A144E1264B3C8D002DCC4D /* AuthenticateTests.swift in Sources */,
 				96AD28A6264A01ED00829BF7 /* OktaIdxAuthTests.swift in Sources */,
 				96AD289D264A01D000829BF7 /* IDXClientAPIMock.swift in Sources */,
 				96AD289F264A01D000829BF7 /* IDXClientDelegateRecorder.swift in Sources */,
@@ -899,6 +913,7 @@
 				964773E22638C36A0059EBC4 /* IDXAuthenticatorCollection+Extension.swift in Sources */,
 				964773A326387AFC0059EBC4 /* IDXVersion.swift in Sources */,
 				96F5417D258A843300D3995F /* IDXClient+V1ResponseConstructors.swift in Sources */,
+				968CD886264C8D12003F0B44 /* IDXFormValue.swift in Sources */,
 				966A1E80258BEADB00864DB7 /* IDXClientError+Extensions.swift in Sources */,
 				962ABD46263CD47C0049B0C4 /* IDXAuthenticator+InternalExtensions.swift in Sources */,
 				964773F42638C6C70059EBC4 /* IDXFormField.swift in Sources */,
@@ -936,6 +951,7 @@
 				96C584EE258ACEB200E79975 /* JSONValueTests.swift in Sources */,
 				961BE4272583E73300DCE8AC /* IDXClientRequestTests.swift in Sources */,
 				961BE42F2583EC6300DCE8AC /* TestExtensions.swift in Sources */,
+				968CD890264CA119003F0B44 /* IDXFormValueTests.swift in Sources */,
 				960CD21225D5BC2D00523192 /* URLSessionAuditTests.swift in Sources */,
 				964A44E1259D3331002CB250 /* IDXClientV1ResponseTests.swift in Sources */,
 				96F8F1C125804A0C00DA2701 /* IDXClientVersionTests.swift in Sources */,


### PR DESCRIPTION
Note: This PR is being made so a follow-up PR can relocate / move the direct auth features.