### PR TITLE
Account for authenticators without a displayName property

### DIFF
--- a/Sources/OktaIdx/IDXAuthenticator.swift
+++ b/Sources/OktaIdx/IDXAuthenticator.swift
@@ -82,7 +82,7 @@ extension IDXClient {
         public let id: String
 
         /// The user-visible name to use for this authenticator enrollment.
-        @objc public let displayName: String
+        @objc public let displayName: String?
 
         /// The type of this authenticator, or `unknown` if the type isn't represented by this enumeration.
         @objc public let type: Kind
@@ -111,7 +111,7 @@ extension IDXClient {
              v1JsonPaths: [String],
              state: State,
              id: String,
-             displayName: String,
+             displayName: String?,
              type: String,
              key: String?,
              methods: [[String:String]]?)
@@ -194,7 +194,7 @@ extension IDXClient {
                           v1JsonPaths: [String],
                           state: State,
                           id: String,
-                          displayName: String,
+                          displayName: String?,
                           type: String,
                           key: String?,
                           methods: [[String:String]]?,
@@ -224,7 +224,7 @@ extension IDXClient {
                           v1JsonPaths: [String],
                           state: State,
                           id: String,
-                          displayName: String,
+                          displayName: String?,
                           type: String,
                           key: String?,
                           methods: [[String:String]]?,
@@ -305,7 +305,7 @@ extension IDXClient {
                           v1JsonPaths: [String],
                           state: State,
                           id: String,
-                          displayName: String,
+                          displayName: String?,
                           type: String,
                           key: String?,
                           methods: [[String:String]]?,
@@ -370,7 +370,7 @@ extension IDXClient {
                           v1JsonPaths: [String],
                           state: State,
                           id: String,
-                          displayName: String,
+                          displayName: String?,
                           type: String,
                           key: String?,
                           methods: [[String:String]]?,

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Responses/Responses.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Responses/Responses.swift
@@ -110,11 +110,11 @@ extension IDXClient.APIVersion1 {
         }
         
         struct Authenticator: Decodable, IDXIONRelatable {
-            let displayName: String
+            let displayName: String?
             let id: String
             let type: String
             let key: String?
-            let methods: [[String:String]]
+            let methods: [[String:String]]?
             let settings: [String:JSONValue]?
             let contextualData: [String:JSONValue]?
             let profile: [String:String]?

--- a/Tests/OktaIdxTests/IDXClientV1ResponseTests.swift
+++ b/Tests/OktaIdxTests/IDXClientV1ResponseTests.swift
@@ -540,6 +540,32 @@ class IDXClientV1ResponseTests: XCTestCase {
         }
     }
 
+    func testAuthenticatorWithNullDisplayName() throws {
+        try decode(type: API.Response.IonObject<API.Response.Authenticator>.self, """
+        {
+          "type" : "object",
+          "value" : {
+             "id" : "lae8wj8nnjB3BrbcH0g6",
+             "key" : "okta_oth",
+             "type" : "other"
+          }
+        }
+        """) { (obj) in
+            XCTAssertEqual(obj.type, "object")
+            XCTAssertEqual(obj.value.id, "lae8wj8nnjB3BrbcH0g6")
+            XCTAssertNil(obj.value.displayName)
+            XCTAssertNil(obj.value.methods)
+
+            let publicObj = try XCTUnwrap(IDXClient.Authenticator.makeAuthenticator(client: clientMock,
+                                                                                    v1: [obj.value],
+                                                                                    jsonPaths: [],
+                                                                                    in: response) as? IDXClient.Authenticator)
+            XCTAssertEqual(publicObj.id, "lae8wj8nnjB3BrbcH0g6")
+            XCTAssertNil(publicObj.displayName)
+            XCTAssertNil(publicObj.methods)
+        }
+    }
+
     func testIdpRemediation() throws {
         try decode(type: API.Response.Form.self, """
         {


### PR DESCRIPTION
Bug report from Joe Burgett when testing against a different org, where authenticators didn't return a `displayName` property.