### PR TITLE
Fix the case where an authenticator may be referenced by JSON pointer, but does not have an ID

### DIFF
--- a/Samples/EmbeddedAuthWithSDKs/EmbeddedAuth/View Controllers/LandingViewController.swift
+++ b/Samples/EmbeddedAuthWithSDKs/EmbeddedAuth/View Controllers/LandingViewController.swift
@@ -77,10 +77,6 @@ class LandingViewController: UIViewController {
                 print("Could not sign in: \(error)")
             } else {
                 UserManager.shared.current = user
-//                guard let controller = self?.storyboard?.instantiateViewController(identifier: "TokenResult") as? TokenResultViewController else { return }
-//                controller.client = self?.signin?.idx
-//                controller.token = user?.token
-//                self?.navigationController?.pushViewController(controller, animated: true)
             }
         }
     }

--- a/Samples/EmbeddedAuthWithSDKs/EmbeddedAuth/View Controllers/LandingViewController.swift
+++ b/Samples/EmbeddedAuthWithSDKs/EmbeddedAuth/View Controllers/LandingViewController.swift
@@ -72,7 +72,7 @@ class LandingViewController: UIViewController {
             return
         }
         
-        signin.signin(from: self) { [weak self] (user, error) in
+        signin.signin(from: self) { (user, error) in
             if let error = error {
                 print("Could not sign in: \(error)")
             } else {

--- a/Sources/OktaIdx/Extensions/EnumExtensions.swift
+++ b/Sources/OktaIdx/Extensions/EnumExtensions.swift
@@ -130,3 +130,32 @@ extension IDXClient.Remediation.SocialAuth.Service {
         }
     }
 }
+
+extension IDXClient.Authenticator.Method {
+    public var stringValue: String? {
+        switch self {
+        case .sms:
+            return "sms"
+        case .voice:
+            return "voice"
+        case .email:
+            return "email"
+        case .push:
+            return "push"
+        case .crypto:
+            return "crypto"
+        case .signedNonce:
+            return "signedNonce"
+        case .totp:
+            return "totp"
+        case .password:
+            return "password"
+        case .webAuthN:
+            return "webAuthN"
+        case .securityQuestion:
+            return "securityQuestion"
+        case .unknown:
+            return nil
+        }
+    }
+}

--- a/Sources/OktaIdx/Extensions/IDXClientError+Extensions.swift
+++ b/Sources/OktaIdx/Extensions/IDXClientError+Extensions.swift
@@ -88,6 +88,9 @@ extension IDXClientError: LocalizedError {
         case .missingRefreshToken:
             return NSLocalizedString("Cannot perform a refresh when no refresh token is available.",
                                      comment: "Cannot perform a refresh when no refresh token is available.")
+        case .missingRelatedObject:
+            return NSLocalizedString("Could not find an object within the response related from another object.",
+                                     comment: "Cannot find a related object in the response.")
         }
     }
 }
@@ -113,6 +116,7 @@ extension IDXClientError: CustomNSError {
         case .successResponseMissing: return 13
         case .internalError(message: _): return 14
         case .missingRefreshToken: return 15
+        case .missingRelatedObject: return 16
         }
     }
 
@@ -124,6 +128,7 @@ extension IDXClientError: CustomNSError {
         case .invalidResponseData: fallthrough
         case .invalidRequestData: fallthrough
         case .missingRefreshToken: fallthrough
+        case .missingRelatedObject: fallthrough
         case .successResponseMissing:
             return [:]
         case .serverError(message: let message, localizationKey: let localizationKey, type: let type):

--- a/Sources/OktaIdx/IDXAuthenticatorType.swift
+++ b/Sources/OktaIdx/IDXAuthenticatorType.swift
@@ -15,7 +15,7 @@ import Foundation
 extension IDXClient.Authenticator {
     @objc(IDXAuthenticatorState)
     public enum State: Int {
-        case normal, enrolled, authenticating, enrolling
+        case normal, enrolled, authenticating, enrolling, recovery
     }
     
     /// The type of authenticator.

--- a/Sources/OktaIdx/IDXClient.swift
+++ b/Sources/OktaIdx/IDXClient.swift
@@ -165,4 +165,5 @@ public enum IDXClientError: Error {
     case unknownRemediationOption(name: String)
     case successResponseMissing
     case missingRefreshToken
+    case missingRelatedObject
 }

--- a/Tests/OktaIdxTests/IDXAuthenticatorCollectionTests.swift
+++ b/Tests/OktaIdxTests/IDXAuthenticatorCollectionTests.swift
@@ -47,4 +47,18 @@ class IDXAuthenticatorCollectionTests: XCTestCase {
         XCTAssertEqual(remediation.authenticators.count, 1)
         XCTAssertEqual(remediation.authenticators.first?.type, .password)
     }
+    
+    func testAuthenticatorEnrollmentWithoutId() throws {
+        let response = try XCTUnwrap(IDXClient.Response.response(client: client,
+                                                                 fileName: "account-recovery"))
+        
+        let remediation = try XCTUnwrap(response.remediations[.selectAuthenticatorAuthenticate])
+        let emailOption = try XCTUnwrap(remediation["authenticator"]?.options?.first)
+        
+        XCTAssertEqual(emailOption.label, "Email")
+        
+        let authenticator = try XCTUnwrap(emailOption.authenticator)
+        XCTAssertEqual(authenticator.type, .email)
+        XCTAssertEqual(authenticator.state, .enrolled)
+    }
 }

--- a/Tests/TestCommon/Resources/account-recovery.json
+++ b/Tests/TestCommon/Resources/account-recovery.json
@@ -1,0 +1,136 @@
+{
+   "app" : {
+      "type" : "object",
+      "value" : {
+         "id" : "0ZczewGCFPlxNYYcLq5i",
+         "label": "API Demo App",
+         "name" : "oidc_client"
+      }
+   },
+   "authenticatorEnrollments" : {
+      "type" : "array",
+      "value" : [
+         {
+            "displayName" : "Email",
+            "key" : "okta_email",
+            "methods" : [
+               {
+                  "type" : "email"
+               }
+            ],
+            "type" : "email"
+         }
+      ]
+   },
+   "authenticators" : {
+      "type" : "array",
+      "value" : [
+         {
+            "displayName" : "Email",
+            "id" : "auttcd6chMKSpJxFO5d6",
+            "key" : "okta_email",
+            "methods" : [
+               {
+                  "type" : "email"
+               }
+            ],
+            "type" : "email"
+         }
+      ]
+   },
+   "cancel" : {
+      "accepts" : "application/json; okta-version=1.0.0",
+      "href" : "https://ios-idx-sdk.okta.com/idp/idx/cancel",
+      "method" : "POST",
+      "name" : "cancel",
+      "produces" : "application/ion+json; okta-version=1.0.0",
+      "rel" : [
+         "create-form"
+      ],
+      "value" : [
+         {
+            "mutable" : false,
+            "name" : "stateHandle",
+            "required" : true,
+            "value" : "ahc52KautBHCANs3ScZjLfRcxFjP_N5mqOTYouqHFP",
+            "visible" : false
+         }
+      ]
+   },
+   "expiresAt" : "2021-07-13T20:49:38.000Z",
+   "intent" : "LOGIN",
+   "recoveryAuthenticator" : {
+      "type" : "object",
+      "value" : {
+         "displayName" : "Password",
+         "id" : "auttcd6cgpdPok11J5d6",
+         "key" : "okta_password",
+         "methods" : [
+            {
+               "type" : "password"
+            }
+         ],
+         "type" : "password"
+      }
+   },
+   "remediation" : {
+      "type" : "array",
+      "value" : [
+         {
+            "accepts" : "application/json; okta-version=1.0.0",
+            "href" : "https://ios-idx-sdk.okta.com/idp/idx/challenge",
+            "method" : "POST",
+            "name" : "select-authenticator-authenticate",
+            "produces" : "application/ion+json; okta-version=1.0.0",
+            "rel" : [
+               "create-form"
+            ],
+            "value" : [
+               {
+                  "name" : "authenticator",
+                  "options" : [
+                     {
+                        "label" : "Email",
+                        "relatesTo" : "$.authenticatorEnrollments.value[0]",
+                        "value" : {
+                           "form" : {
+                              "value" : [
+                                 {
+                                    "mutable" : false,
+                                    "name" : "id",
+                                    "required" : true,
+                                    "value" : "auttcd6chMKSpJxFO5d6"
+                                 },
+                                 {
+                                    "mutable" : false,
+                                    "name" : "methodType",
+                                    "required" : false,
+                                    "value" : "email"
+                                 }
+                              ]
+                           }
+                        }
+                     }
+                  ],
+                  "type" : "object"
+               },
+               {
+                  "mutable" : false,
+                  "name" : "stateHandle",
+                  "required" : true,
+                  "value" : "ahc52KautBHCANs3ScZjLfRcxFjP_N5mqOTYouqHFP",
+                  "visible" : false
+               }
+            ]
+         }
+      ]
+   },
+   "stateHandle" : "ahc52KautBHCANs3ScZjLfRcxFjP_N5mqOTYouqHFP",
+   "user" : {
+      "type" : "object",
+      "value" : {
+         "identifier" : "someuser@example.com"
+      }
+   },
+   "version" : "1.0.0"
+}


### PR DESCRIPTION
Some authenticators may not include an ID at times due to different server policies, but still contain information relevant to objects (remediations or fields) that contain a `relatesTo` property. 

When authenticator information is coalesced, these objects shouldn't be omitted and should still be referenced from their related objects. 