### PR TITLE
Introduce Result completion types

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Each step in the authentication process is represented by an `IDXClient.Response
 
 When a remediation is selected and its inputs have been supplied by the user, the `proceed()` method can be called on the remediation to proceed to the next step of the authentication process.  This returns another `IDXClient.Response` object, which causes the process to continue. 
 
+> **Note:** Unless documented otherwise, all asynchronous functions accept either a Swift `Result` completion handler, or a conventional completion block that provides the response and error as separate values in the argument tuple.
+
 ## Usage
 
 The below code snippets will help you understand how to use this library.
@@ -87,10 +89,12 @@ let config = IDXClient.Configuration(
 ### Create the Client
 
 ```swift
-IDXClient.start(with: configuration) { (client, error) in
-    guard let client = client else {
+IDXClient.start(with: configuration) { result in
+    switch result {
+    case .success(let response):
+        // Handle the response
+    case .failure(let error):
         // Handle the error
-        return
     }
 }
 ```
@@ -98,13 +102,13 @@ IDXClient.start(with: configuration) { (client, error) in
 ### Start / continue the authentication session
 
 ```swift
-client.resume { (response, error) in
-    guard let response = response else {
-        // Handle error
-        return
+client.resume { result in
+    switch result {
+    case .success(let response):
+        // Use the response
+    case .failure(let error):
+        // Handle the error
     }
-    
-    // Use response
 }
 ```
 

--- a/Samples/EmbeddedAuthWithSDKs/EmbeddedAuth/Signin/Protocols/IDXSigninController.swift
+++ b/Samples/EmbeddedAuthWithSDKs/EmbeddedAuth/Signin/Protocols/IDXSigninController.swift
@@ -13,7 +13,7 @@
 import UIKit
 import OktaIdx
 
-protocol IDXSigninController: class {
+protocol IDXSigninController: AnyObject {
     var signin: Signin? { get set }
     func showError(_ error: Error, recoverable: Bool)
 }

--- a/Sources/OktaIdx/IDXClient.swift
+++ b/Sources/OktaIdx/IDXClient.swift
@@ -22,13 +22,15 @@ public final class IDXClient: NSObject {
     /// - Parameters:
     ///   - response: The `IDXClient.Response` object that describes the next workflow steps.
     ///   - error: Describes the error that occurred, or `nil` if the request was successful.
-    public typealias ResponseResult = (_ response: Response?, _ error: Error?) -> Void
-    
+    public typealias ResponseResultCallback = (_ response: Response?, _ error: Error?) -> Void
+    public typealias ResponseResult = (Result<IDXClient.Response, IDXClientError>) -> Void
+
     /// The type used for the completion  handler result from any method that returns an `IDXClient.Token`.
     /// - Parameters:
     ///   - token: The `IDXClient.Token` object created when the token is successfully exchanged.
     ///   - error: Describes the error that occurred, or `nil` if the request was successful.
-    public typealias TokenResult = (_ token: Token?, _ error: Error?) -> Void
+    public typealias TokenResultCallback = (_ token: Token?, _ error: Error?) -> Void
+    public typealias TokenResult = (Result<Token, IDXClientError>) -> Void
 
     /// The current context for the authentication session.
     ///
@@ -43,26 +45,44 @@ public final class IDXClient: NSObject {
     ///   - configuration: Configuration describing the app settings to contact.
     ///   - state: Optional state string to use within the OAuth2 transaction.
     ///   - completion: Completion block to be invoked when a client is created, or when an error is received.
-    @objc public static func start(with configuration: Configuration,
-                                   state: String? = nil,
-                                   completion: @escaping (_ client: IDXClient?, _ error: Error?) -> Void)
+    public static func start(with configuration: Configuration,
+                             state: String? = nil,
+                             completion: @escaping (Result<IDXClient, IDXClientError>) -> Void)
     {
         let api = Version.latest.clientImplementation(with: configuration)
         start(with: api, state: state, completion: completion)
     }
+
+    /// Starts a new authentication session using the given configuration values. If the client is able to successfully interact with Okta Identity Engine, a new client instance is returned to the caller.
+    /// - Parameters:
+    ///   - configuration: Configuration describing the app settings to contact.
+    ///   - state: Optional state string to use within the OAuth2 transaction.
+    ///   - completion: Completion block to be invoked when a client is created, or when an error is received.
+    @objc public static func start(with configuration: Configuration,
+                                   state: String? = nil,
+                                   completion: @escaping (_ client: IDXClient?, _ error: Error?) -> Void)
+    {
+        start(with: configuration, state: state) { result in
+            switch result {
+            case .failure(let error):
+                completion(nil, error)
+            case .success(let client):
+                completion(client, nil)
+            }
+        }
+    }
     
     static func start(with api: IDXClientAPIImpl,
                       state: String? = nil,
-                      completion: @escaping (_ client: IDXClient?, _ error: Error?) -> Void)
+                      completion: @escaping (Result<IDXClient, IDXClientError>) -> Void)
     {
-        api.start(state: state) { (context, error) in
-            guard let context = context else {
-                completion(nil, error)
-                return
+        api.start(state: state) { result in
+            switch result {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let context):
+                completion(.success(IDXClient(context: context, api: api)))
             }
-            
-            let client = IDXClient(context: context, api: api)
-            completion(client, nil)
         }
     }
     
@@ -83,9 +103,27 @@ public final class IDXClient: NSObject {
     ///   - completion: Optional completion handler invoked when a response is received.
     ///   - response: The response describing the new workflow next steps, or `nil` if an error occurred.
     ///   - error: Describes the error that occurred, or `nil` if successful.
-    @objc public func resume(completion: ResponseResult?) {
-        api.resume { (response, error) in
-            self.handleResponse(response, error: error, completion: completion)
+    @objc public func resume(completion: ResponseResultCallback?) {
+        resume() { result in
+            switch result {
+            case .success(let response):
+                completion?(response, nil)
+            case .failure(let error):
+                completion?(nil, error)
+            }
+        }
+    }
+
+    /// Resumes the authentication state to identify the available remediation steps.
+    ///
+    /// This method is usually performed after an IDXClient is created in `IDXClient.start(with:state:completion:)`, but can also be called at any time to identify what next remediation steps are available to the user.
+    /// - Important:
+    /// If a completion handler is not provided, you should ensure that you implement the `IDXClientDelegate.idx(client:didReceive:)` methods to process any response or error returned from this call.
+    /// - Parameters:
+    ///   - completion: Optional completion handler invoked when a response is received.
+    public func resume(completion: ResponseResult? = nil) {
+        api.resume { result in
+            self.handleResponse(result, completion: completion)
         }
     }
     
@@ -107,12 +145,30 @@ public final class IDXClient: NSObject {
     ///   - completion: Optional completion handler invoked when a token, or error, is received.
     @objc(exchangeCodeWithRedirectUrl:completion:)
     public func exchangeCode(redirect url: URL,
-                             completion: TokenResult?) {
-        api.exchangeCode(redirect: url) { (token, error) in
-            self.handleResponse(token, error: error, completion: completion)
+                             completion: TokenResultCallback?) {
+        exchangeCode(redirect: url) { result in
+            switch result {
+            case .success(let token):
+                completion?(token, nil)
+            case .failure(let error):
+                completion?(nil, error)
+            }
         }
     }
-    
+
+    /// Exchanges the redirect URL with a token.
+    ///
+    /// Once the `redirectResult` method returns `authenticated`, the developer can exchange that redirect URL for a valid token by using this method.
+    /// - Parameters:
+    ///   - url: URL with the app’s custom scheme. The value must match one of the authorized redirect URIs, which are configured in Okta Admin Console.
+    ///   - completion: Optional completion handler invoked when a token, or error, is received.
+    public func exchangeCode(redirect url: URL,
+                             completion: TokenResult? = nil) {
+        api.exchangeCode(redirect: url) { result in
+            self.handleResponse(result, completion: completion)
+        }
+    }
+
     internal let api: IDXClientAPIImpl
     internal required init(context: Context, api: IDXClientAPIImpl) {
         self.context = context
@@ -177,11 +233,14 @@ public enum IDXClientError: Error {
     case invalidResponseData
     case invalidRequestData
     case serverError(message: String, localizationKey: String, type: String)
-    case internalError(message: String)
+    case internalError(_: Error)
+    case internalMessage(_: String)
+    case oauthError(summary: String, code: String?, errorId: String?)
     case invalidParameter(name: String)
     case invalidParameterValue(name: String, type: String)
     case parameterImmutable(name: String)
     case missingRequiredParameter(name: String)
+    case missingRemediationOption(name: String)
     case unknownRemediationOption(name: String)
     case successResponseMissing
     case missingRefreshToken

--- a/Sources/OktaIdx/Internal/Implementations/IDXClientAPIImpl.swift
+++ b/Sources/OktaIdx/Internal/Implementations/IDXClientAPIImpl.swift
@@ -39,24 +39,24 @@ protocol IDXClientAPIImpl: AnyObject {
     /// The upstream client to communicate critical events to
     var client: IDXClientAPI? { get set }
     
-    func start(state: String?, completion: @escaping (IDXClient.Context?, Error?) -> Void)
-    func resume(completion: @escaping (_ reponse: IDXClient.Response?, _ error: Error?) -> Void)
+    func start(state: String?, completion: @escaping (Result<IDXClient.Context, IDXClientError>) -> Void)
+    func resume(completion: @escaping (Result<IDXClient.Response, IDXClientError>) -> Void)
     func proceed(remediation option: IDXClient.Remediation,
-                 completion: @escaping (_ response: IDXClient.Response?, _ error: Swift.Error?) -> Void)
+                 completion: @escaping (Result<IDXClient.Response, IDXClientError>) -> Void)
     
     func redirectResult(for url: URL) -> IDXClient.RedirectResult
     
     func exchangeCode(redirect url: URL,
-                      completion: @escaping (_ token: IDXClient.Token?, _ error: Swift.Error?) -> Void)
+                      completion: @escaping (Result<IDXClient.Token, IDXClientError>) -> Void)
     
     func exchangeCode(using remediation: IDXClient.Remediation,
-                      completion: @escaping (_ token: IDXClient.Token?, _ error: Swift.Error?) -> Void)
+                      completion: @escaping (Result<IDXClient.Token, IDXClientError>) -> Void)
 
     func revoke(token: String,
                 type: String,
-                completion: @escaping(_ successful: Bool, _ error: Error?) -> Void)
+                completion: @escaping(Result<Void, IDXClientError>) -> Void)
     func refresh(token: IDXClient.Token,
-                 completion: @escaping(_ token: IDXClient.Token?, _ error: Error?) -> Void)
+                 completion: @escaping(Result<IDXClient.Token, IDXClientError>) -> Void)
 }
 
 /// Protocol used to represent IDX API requests, and their expected response types.
@@ -73,7 +73,7 @@ protocol IDXClientAPIRequest {
     ///   - completion: Completion handler to receive the response.
     func send(to session: URLSessionProtocol,
               using configuration: IDXClient.Configuration,
-              completion: @escaping (ResponseType?, Error?) -> Void)
+              completion: @escaping (Result<ResponseType, IDXClientError>) -> Void)
 }
 
 protocol IDXResponseJSONPath {

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Extensions/JSONValue.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Extensions/JSONValue.swift
@@ -117,7 +117,7 @@ extension JSONValue: Codable {
         case let .array(value):
             try container.encode(value)
         case .object(_):
-            throw IDXClientError.internalError(message: "Unable to encode object as JSON")
+            throw IDXClientError.internalMessage("Unable to encode object as JSON")
         case .null:
             try container.encodeNil()
         }

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Requests/InteractRequest.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Requests/InteractRequest.swift
@@ -46,21 +46,21 @@ extension IDXClient.APIVersion1.InteractRequest: IDXClientAPIRequest {
     
     func send(to session: URLSessionProtocol,
               using configuration: IDXClient.Configuration,
-              completion: @escaping (ResponseType?, Error?) -> Void)
+              completion: @escaping (Result<ResponseType, IDXClientError>) -> Void)
     {
         guard let request = urlRequest(using: configuration) else {
-            completion(nil, IDXClientError.cannotCreateRequest)
+            completion(.failure(.cannotCreateRequest))
             return
         }
         
         let task = session.dataTaskWithRequest(with: request) { (data, response, error) in
             guard error == nil else {
-                completion(nil, error)
+                completion(.failure(.internalError(error!)))
                 return
             }
             
             guard let data = data else {
-                completion(nil, IDXClientError.invalidResponseData)
+                completion(.failure(.invalidResponseData))
                 return
             }
             
@@ -71,11 +71,11 @@ extension IDXClient.APIVersion1.InteractRequest: IDXClientAPIRequest {
             do {
                 result = try decoder.decode(ResponseType.self, from: data)
             } catch {
-                completion(nil, error)
+                completion(.failure(.internalError(error)))
                 return
             }
 
-            completion(result, nil)
+            completion(.success(result))
         }
         task.resume()
     }

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Requests/IntrospectRequest.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Requests/IntrospectRequest.swift
@@ -44,21 +44,21 @@ extension IDXClient.APIVersion1.IntrospectRequest: IDXClientAPIRequest, Receives
     
     func send(to session: URLSessionProtocol,
               using configuration: IDXClient.Configuration,
-              completion: @escaping (ResponseType?, Error?) -> Void)
+              completion: @escaping (Result<ResponseType, IDXClientError>) -> Void)
     {
         guard let request = urlRequest(using: configuration) else {
-            completion(nil, IDXClientError.cannotCreateRequest)
+            completion(.failure(.cannotCreateRequest))
             return
         }
         
         let task = session.dataTaskWithRequest(with: request) { (data, response, error) in
             guard error == nil else {
-                completion(nil, error)
+                completion(.failure(.internalError(error!)))
                 return
             }
             
             guard let data = data else {
-                completion(nil, IDXClientError.invalidResponseData)
+                completion(.failure(.invalidResponseData))
                 return
             }
             
@@ -66,11 +66,11 @@ extension IDXClient.APIVersion1.IntrospectRequest: IDXClientAPIRequest, Receives
             do {
                 result = try self.idxResponse(from: data)
             } catch {
-                completion(nil, error)
+                completion(.failure(.internalError(error)))
                 return
             }
 
-            completion(result, nil)
+            completion(.success(result))
         }
         task.resume()
     }

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Requests/RemediationRequest.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Requests/RemediationRequest.swift
@@ -49,21 +49,21 @@ extension IDXClient.APIVersion1.RemediationRequest: IDXClientAPIRequest, Receive
 
     func send(to session: URLSessionProtocol,
               using configuration: IDXClient.Configuration,
-              completion: @escaping (ResponseType?, Error?) -> Void)
+              completion: @escaping (Result<ResponseType, IDXClientError>) -> Void)
     {
         guard let request = urlRequest(using: configuration) else {
-            completion(nil, IDXClientError.cannotCreateRequest)
+            completion(.failure(.cannotCreateRequest))
             return
         }
         
         let task = session.dataTaskWithRequest(with: request) { (data, response, error) in
             guard error == nil else {
-                completion(nil, error)
+                completion(.failure(.internalError(error!)))
                 return
             }
             
             guard let data = data else {
-                completion(nil, IDXClientError.invalidResponseData)
+                completion(.failure(.invalidResponseData))
                 return
             }
             
@@ -71,11 +71,11 @@ extension IDXClient.APIVersion1.RemediationRequest: IDXClientAPIRequest, Receive
             do {
                 result = try self.idxResponse(from: data)
             } catch {
-                completion(nil, error)
+                completion(.failure(.internalError(error)))
                 return
             }
 
-            completion(result, nil)
+            completion(.success(result))
         }
         task.resume()
     }

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Requests/TokenRequest.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Requests/TokenRequest.swift
@@ -79,21 +79,21 @@ extension IDXClient.APIVersion1.TokenRequest: IDXClientAPIRequest {
 
     func send(to session: URLSessionProtocol,
               using configuration: IDXClient.Configuration,
-              completion: @escaping (ResponseType?, Error?) -> Void)
+              completion: @escaping (Result<ResponseType, IDXClientError>) -> Void)
     {
         guard let request = urlRequest(using: configuration) else {
-            completion(nil, IDXClientError.cannotCreateRequest)
+            completion(.failure(.cannotCreateRequest))
             return
         }
         
         let task = session.dataTaskWithRequest(with: request) { (data, response, error) in
             guard error == nil else {
-                completion(nil, error)
+                completion(.failure(.internalError(error!)))
                 return
             }
             
             guard let data = data else {
-                completion(nil, IDXClientError.invalidResponseData)
+                completion(.failure(.invalidResponseData))
                 return
             }
             
@@ -104,11 +104,11 @@ extension IDXClient.APIVersion1.TokenRequest: IDXClientAPIRequest {
             do {
                 result = try decoder.decode(ResponseType.self, from: data)
             } catch {
-                completion(nil, error)
+                completion(.failure(.internalError(error)))
                 return
             }
 
-            completion(result, nil)
+            completion(.success(result))
         }
         task.resume()
     }

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Responses/IDXClient+V1ResponseConstructors.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Responses/IDXClient+V1ResponseConstructors.swift
@@ -207,7 +207,7 @@ extension IDXClient.Authenticator {
 
         let filteredTypes = Set(authenticators.map({ $0.type }))
         guard filteredTypes.count == 1 else {
-            throw IDXClientError.internalError(message: "Some mapped authenticators have differing types: \(filteredTypes.joined(separator: ", "))")
+            throw IDXClientError.internalMessage("Some mapped authenticators have differing types: \(filteredTypes.joined(separator: ", "))")
         }
         
         let type = IDXClient.Authenticator.Kind(string: first.type)

--- a/Sources/OktaIdx/Internal/Utilities/PollingHandler.swift
+++ b/Sources/OktaIdx/Internal/Utilities/PollingHandler.swift
@@ -41,7 +41,7 @@ class PollingHandler {
         guard let refreshTime = delegate?.pollingRefreshTime(handler: self),
               refreshTime > 0
         else {
-            if !completion(nil, IDXClientError.internalError(message: "Missing polling information")) {
+            if !completion(nil, IDXClientError.internalMessage("Missing polling information")) {
                 stopPolling()
             }
             return

--- a/Tests/OktaIdxTests/IDXClientAPIVersion1Tests.swift
+++ b/Tests/OktaIdxTests/IDXClientAPIVersion1Tests.swift
@@ -41,10 +41,13 @@ class IDXClientAPIVersion1Tests: XCTestCase {
         try session.expect("https://foo.oktapreview.com/oauth2/default/v1/interact", fileName: "interact-response")
         
         let completion = expectation(description: "Response")
-        api.start(state: nil) { (context, error) in
-            XCTAssertNotNil(context)
-            XCTAssertEqual(context?.interactionHandle, "003Q14X7li")
-            XCTAssertNil(error)
+        api.start(state: nil) { result in
+            if case let Result.success(context) = result {
+                XCTAssertNotNil(context)
+                XCTAssertEqual(context.interactionHandle, "003Q14X7li")
+            } else {
+                XCTFail("Not successful")
+            }
             completion.fulfill()
         }
         wait(for: [completion], timeout: 1)
@@ -56,9 +59,12 @@ class IDXClientAPIVersion1Tests: XCTestCase {
                            statusCode: 400)
         
         let completion = expectation(description: "Response")
-        api.start(state: nil) { (context, error) in
-            XCTAssertNil(context)
-            XCTAssertNotNil(error)
+        api.start(state: nil) { result in
+            if case let Result.failure(error) = result {
+                XCTAssertEqual(error, .invalidResponseData)
+            } else {
+                XCTFail("Received success response when a failure was expected")
+            }
             completion.fulfill()
         }
         wait(for: [completion], timeout: 1)
@@ -70,10 +76,12 @@ class IDXClientAPIVersion1Tests: XCTestCase {
 
         var response: IDXClient.Response!
         let completion = expectation(description: "Response")
-        api.resume { (responseValue, error) in
-            XCTAssertNotNil(responseValue)
-            XCTAssertNil(error)
-            response = responseValue
+        api.resume { result in
+            if case let Result.success(responseValue) = result {
+                response = responseValue
+            } else {
+                XCTFail("Error received when a success was expected")
+            }
             completion.fulfill()
         }
         wait(for: [completion], timeout: 1)
@@ -130,11 +138,12 @@ class IDXClientAPIVersion1Tests: XCTestCase {
                            statusCode: 400)
         
         let completion = expectation(description: "Response")
-        api.resume { (response, error) in
-            XCTAssertNil(response)
-            XCTAssertNotNil(error)
-            XCTAssertTrue(error is IDXClientError)
-            
+        api.resume { result in
+            if case let Result.failure(error) = result {
+                XCTAssertEqual(error, .invalidResponseData)
+            } else {
+                XCTFail("Received success response when a failure was expected")
+            }
             completion.fulfill()
         }
         wait(for: [completion], timeout: 1)

--- a/Tests/OktaIdxTests/IDXClientDelegateTests.swift
+++ b/Tests/OktaIdxTests/IDXClientDelegateTests.swift
@@ -114,7 +114,7 @@ class IDXClientDelegateTests: XCTestCase {
     func testProceedError() {
         api.expect(function: "proceed(remediation:completion:)", arguments: ["error": error])
         waitFor { expectation in
-            self.client.proceed(remediation: self.remediationOption) { (_, _) in
+            self.client.proceed(remediation: self.remediationOption) { result in
                 expectation.fulfill()
             }
         }
@@ -136,7 +136,7 @@ class IDXClientDelegateTests: XCTestCase {
     func testExchangeCodeError() {
         api.expect(function: "exchangeCode(using:completion:)", arguments: ["error": error])
         waitFor { expectation in
-            self.client.exchangeCode(using: self.remediationOption) { (_, _) in
+            self.client.exchangeCode(using: self.remediationOption) { result in
                 expectation.fulfill()
             }
         }
@@ -146,9 +146,9 @@ class IDXClientDelegateTests: XCTestCase {
     
     func testToken() {
         // exchangeCode()
-        api.expect(function: "exchangeCode(using:completion:)", arguments: ["token": token as Any])
+        api.expect(function: "exchangeCode(using:completion:)", arguments: ["response": token as Any])
         waitFor { expectation in
-            self.client.exchangeCode(using: self.remediationOption) { (_, _) in
+            self.client.exchangeCode(using: self.remediationOption) { result in
                 expectation.fulfill()
             }
         }
@@ -158,7 +158,7 @@ class IDXClientDelegateTests: XCTestCase {
     }
     
     func testExchangeCodeRedirectUrlFromClient() {
-        api.expect(function: "exchangeCode(redirect:completion:)", arguments: ["token": token as Any])
+        api.expect(function: "exchangeCode(redirect:completion:)", arguments: ["response": token as Any])
         waitFor { expectation in
             self.client.exchangeCode(redirect: self.redirectUrl) { (_, _) in
                 expectation.fulfill()
@@ -170,7 +170,7 @@ class IDXClientDelegateTests: XCTestCase {
     }
 
     func testExchangeCodeFromResponse() {
-        api.expect(function: "exchangeCode(using:completion:)", arguments: ["token": token as Any])
+        api.expect(function: "exchangeCode(using:completion:)", arguments: ["response": token as Any])
         waitFor { expectation in
             self.response.exchangeCode { (_, _) in
                 expectation.fulfill()
@@ -221,7 +221,7 @@ class IDXClientDelegateTests: XCTestCase {
     func testResumeWithoutCompletionBlock() {
         api.expect(function: "resume(completion:)", arguments: ["response": response as Any])
         waitFor { expectation in
-            self.client.resume(completion: nil)
+            self.client.resume { response, error in }
             expectation.fulfill()
         }
         XCTAssertEqual(delegate.calls.count, 1)
@@ -231,9 +231,9 @@ class IDXClientDelegateTests: XCTestCase {
     
     func testExchangeCodeRedirectWithoutCompletionBlock() {
         // exchangeCode()
-        api.expect(function: "exchangeCode(redirect:completion:)", arguments: ["token": token as Any])
+        api.expect(function: "exchangeCode(redirect:completion:)", arguments: ["response": token as Any])
         waitFor { expectation in
-            self.client.exchangeCode(redirect: self.redirectUrl, completion: nil)
+            self.client.exchangeCode(redirect: self.redirectUrl) { token, error in }
             expectation.fulfill()
         }
         XCTAssertEqual(delegate.calls.count, 1)
@@ -242,9 +242,9 @@ class IDXClientDelegateTests: XCTestCase {
     }
     
     func testExchangeCodeWithoutCompletionBlock() {
-        api.expect(function: "exchangeCode(using:completion:)", arguments: ["token": token as Any])
+        api.expect(function: "exchangeCode(using:completion:)", arguments: ["response": token as Any])
         waitFor { expectation in
-            self.response.exchangeCode(completion: nil)
+            self.response.exchangeCode { token, error in }
             expectation.fulfill()
         }
         XCTAssertEqual(delegate.calls.count, 1)
@@ -255,7 +255,7 @@ class IDXClientDelegateTests: XCTestCase {
     func testCancelWithoutCompletionBlock() {
         api.expect(function: "proceed(remediation:completion:)", arguments: ["response": response as Any])
         waitFor { expectation in
-            self.response.cancel(completion: nil)
+            self.response.cancel { response, error in }
             expectation.fulfill()
         }
         XCTAssertEqual(delegate.calls.count, 1)
@@ -266,7 +266,7 @@ class IDXClientDelegateTests: XCTestCase {
     func testProceedWithoutCompletionBlock() {
         api.expect(function: "proceed(remediation:completion:)", arguments: ["response": response as Any])
         waitFor { expectation in
-            self.remediationOption.proceed(completion: nil)
+            self.remediationOption.proceed { response, error in }
             expectation.fulfill()
         }
         XCTAssertEqual(delegate.calls.count, 1)

--- a/Tests/OktaIdxTests/IDXClientErrorTests.swift
+++ b/Tests/OktaIdxTests/IDXClientErrorTests.swift
@@ -66,7 +66,7 @@ class IDXClientErrorTests: XCTestCase {
                        "Message")
         XCTAssertEqual(IDXClientError.invalidParameter(name: "name").localizedDescription,
                        "Invalid parameter \"name\" supplied to a remediation option.")
-        XCTAssertEqual(IDXClientError.internalError(message: "name").localizedDescription,
+        XCTAssertEqual(IDXClientError.internalMessage("name").localizedDescription,
                        "name")
         XCTAssertEqual(IDXClientError.invalidParameterValue(name: "name", type: "string").localizedDescription,
                        "Parameter \"name\" was supplied a string value which is unsupported.")

--- a/Tests/OktaIdxTests/IDXClientTests.swift
+++ b/Tests/OktaIdxTests/IDXClientTests.swift
@@ -76,7 +76,7 @@ class IDXClientTests: XCTestCase {
         
         // start()
         expect = expectation(description: "start")
-        IDXClient.start(with: api, state: "state") { (_, _) in
+        IDXClient.start(with: api, state: "state") { result in
             called = true
             expect.fulfill()
         }
@@ -103,7 +103,7 @@ class IDXClientTests: XCTestCase {
 
         // proceed()
         expect = expectation(description: "proceed")
-        client.proceed(remediation: remedationOption) { (_, _) in
+        client.proceed(remediation: remedationOption) { result in
             called = true
             expect.fulfill()
         }
@@ -117,7 +117,7 @@ class IDXClientTests: XCTestCase {
         
         // exchangeCode()
         expect = expectation(description: "exchangeCode")
-        client.exchangeCode(using: remedationOption) { (_, _) in
+        client.exchangeCode(using: remedationOption) { result in
             called = true
             expect.fulfill()
         }
@@ -145,7 +145,7 @@ class IDXClientTests: XCTestCase {
         
         // revoke()
         expect = expectation(description: "revoke(token:type:completion:)")
-        IDXClient.Token.revoke(token: "token", type: .refreshToken, api: api) { (_, _) in
+        IDXClient.Token.revoke(token: "token", type: .refreshToken, api: api) { result in
             called = true
             expect.fulfill()
         }

--- a/Tests/TestCommon/Mocks/IDXClientAPIMock.swift
+++ b/Tests/TestCommon/Mocks/IDXClientAPIMock.swift
@@ -32,6 +32,16 @@ class MockBase {
     func response(for name: String) -> [String:Any]? {
         return expectations.removeValue(forKey: name)
     }
+    
+    func result<T>(for name: String) -> Result<T, IDXClientError> {
+        let response = response(for: name)
+        if let result = response?["response"] as? T {
+            return .success(result)
+        }
+        
+        let error = response?["error"] as? IDXClientError ?? IDXClientError.invalidClient
+        return .failure(error)
+    }
 }
 
 class IDXClientAPIMock: MockBase, IDXClientAPI {
@@ -44,8 +54,8 @@ class IDXClientAPIMock: MockBase, IDXClientAPI {
     func resume(completion: IDXClient.ResponseResult?) {
         recordedCalls.append(RecordedCall(function: #function,
                                           arguments: [:]))
-        let result = response(for: #function)
-        completion?(result?["response"] as? IDXClient.Response, result?["error"] as? Error)
+        let result: Result<IDXClient.Response, IDXClientError> = result(for: #function)
+        completion?(result)
     }
     
     func proceed(remediation option: IDXClient.Remediation, completion: IDXClient.ResponseResult?) {
@@ -53,8 +63,8 @@ class IDXClientAPIMock: MockBase, IDXClientAPI {
                                           arguments: [
                                             "remediation": option as Any,
                                           ]))
-        let result = response(for: #function)
-        completion?(result?["response"] as? IDXClient.Response, result?["error"] as? Error)
+        let result: Result<IDXClient.Response, IDXClientError> = result(for: #function)
+        completion?(result)
     }
     
     func exchangeCode(redirect url: URL, completion: IDXClient.TokenResult?) {
@@ -62,8 +72,8 @@ class IDXClientAPIMock: MockBase, IDXClientAPI {
                                           arguments: [
                                             "redirect": url as Any
                                           ]))
-        let result = self.response(for: #function)
-        completion?(result?["token"] as? IDXClient.Token, result?["error"] as? Error)
+        let result: Result<IDXClient.Token, IDXClientError> = result(for: #function)
+        completion?(result)
     }
     
     func exchangeCode(using remediation: IDXClient.Remediation, completion: IDXClient.TokenResult?) {
@@ -71,8 +81,8 @@ class IDXClientAPIMock: MockBase, IDXClientAPI {
                                           arguments: [
                                             "using": response as Any
                                           ]))
-        let result = self.response(for: #function)
-        completion?(result?["token"] as? IDXClient.Token, result?["error"] as? Error)
+        let result: Result<IDXClient.Token, IDXClientError> = result(for: #function)
+        completion?(result)
     }
     
     func redirectResult(for url: URL) -> IDXClient.RedirectResult {
@@ -94,28 +104,28 @@ class IDXClientAPIv1Mock: MockBase, IDXClientAPIImpl {
         self.configuration = configuration
     }
     
-    func start(state: String?, completion: @escaping (IDXClient.Context?, Error?) -> Void) {
+    func start(state: String?, completion: @escaping (Result<IDXClient.Context, IDXClientError>) -> Void) {
         recordedCalls.append(RecordedCall(function: #function,
                                           arguments: [
                                             "state": state as Any
                                           ]))
-        let result = response(for: #function)
-        completion(result?["context"] as? IDXClient.Context, result?["error"] as? Error)
+        let result: Result<IDXClient.Context, IDXClientError> = result(for: #function)
+        completion(result)
     }
     
-    func resume(completion: @escaping (IDXClient.Response?, Error?) -> Void) {
+    func resume(completion: @escaping (Result<IDXClient.Response, IDXClientError>) -> Void) {
         recordedCalls.append(RecordedCall(function: #function, arguments: nil))
-        let result = response(for: #function)
-        completion(result?["response"] as? IDXClient.Response, result?["error"] as? Error)
+        let result: Result<IDXClient.Response, IDXClientError> = result(for: #function)
+        completion(result)
     }
     
-    func proceed(remediation option: IDXClient.Remediation, completion: @escaping (IDXClient.Response?, Error?) -> Void) {
+    func proceed(remediation option: IDXClient.Remediation, completion: @escaping (Result<IDXClient.Response, IDXClientError>) -> Void) {
         recordedCalls.append(RecordedCall(function: #function,
                                           arguments: [
                                             "remediation": option as Any,
                                           ]))
-        let result = response(for: #function)
-        completion(result?["response"] as? IDXClient.Response, result?["error"] as? Error)
+        let result: Result<IDXClient.Response, IDXClientError> = result(for: #function)
+        completion(result)
     }
     
     func redirectResult(for url: URL) -> IDXClient.RedirectResult {
@@ -127,40 +137,40 @@ class IDXClientAPIv1Mock: MockBase, IDXClientAPIImpl {
         return result?["result"] as? IDXClient.RedirectResult ?? .invalidContext
     }
     
-    @objc func exchangeCode(redirect url: URL, completion: @escaping (IDXClient.Token?, Error?) -> Void) {
+    func exchangeCode(redirect url: URL, completion: @escaping (Result<IDXClient.Token, IDXClientError>) -> Void) {
         recordedCalls.append(RecordedCall(function: #function,
                                           arguments: [
                                             "redirect": url as Any
                                           ]))
-        let result = self.response(for: #function)
-        completion(result?["token"] as? IDXClient.Token, result?["error"] as? Error)
+        let result: Result<IDXClient.Token, IDXClientError> = result(for: #function)
+        completion(result)
     }
 
-    func exchangeCode(using remediation: IDXClient.Remediation, completion: @escaping (IDXClient.Token?, Error?) -> Void) {
+    func exchangeCode(using remediation: IDXClient.Remediation, completion: @escaping (Result<IDXClient.Token, IDXClientError>) -> Void) {
         recordedCalls.append(RecordedCall(function: #function,
                                           arguments: [
                                             "using": remediation as Any
                                           ]))
-        let result = self.response(for: #function)
-        completion(result?["token"] as? IDXClient.Token, result?["error"] as? Error)
+        let result: Result<IDXClient.Token, IDXClientError> = result(for: #function)
+        completion(result)
     }
-    
-    func revoke(token: String, type: String, completion: @escaping (Bool, Error?) -> Void) {
+
+    func revoke(token: String, type: String, completion: @escaping (Result<Void, IDXClientError>) -> Void) {
         recordedCalls.append(RecordedCall(function: #function,
                                           arguments: [
                                             "token": token as Any,
                                             "type": type as Any
                                           ]))
-        let result = self.response(for: #function)
-        completion(result?["success"] as? Bool ?? true, result?["error"] as? Error)
+        let result: Result<Void, IDXClientError> = result(for: #function)
+        completion(result)
     }
     
-    func refresh(token: IDXClient.Token, completion: @escaping (IDXClient.Token?, Error?) -> Void) {
+    func refresh(token: IDXClient.Token, completion: @escaping (Result<IDXClient.Token, IDXClientError>) -> Void) {
         recordedCalls.append(RecordedCall(function: #function,
                                           arguments: [
                                             "token": token as Any
                                           ]))
-        let result = self.response(for: #function)
-        completion(result?["token"] as? IDXClient.Token, result?["error"] as? Error)
+        let result: Result<IDXClient.Token, IDXClientError> = result(for: #function)
+        completion(result)
     }
 }

--- a/Tests/TestCommon/Utilities/IDXResponse+TestFactory.swift
+++ b/Tests/TestCommon/Utilities/IDXResponse+TestFactory.swift
@@ -137,7 +137,7 @@ extension IDXClient.Response {
             return self
         }
         
-        func when(_ type: IDXClient.Remediation.RemediationType, send error: Error) -> Test {
+        func when(_ type: IDXClient.Remediation.RemediationType, send error: IDXClientError) -> Test {
             guard let remediation = remediations[type] as? IDXClient.Remediation.Test else { return self }
             remediation.proceedError = error
             return self
@@ -148,10 +148,14 @@ extension IDXClient.Response {
 extension IDXClient.Remediation {
     class Test: IDXClient.Remediation {
         fileprivate var proceedResponse: IDXClient.Response.Test?
-        fileprivate var proceedError: Error?
+        fileprivate var proceedError: IDXClientError?
         
         override func proceed(completion: IDXClient.ResponseResult?) {
-            completion?(proceedResponse, proceedError)
+            if let proceedResponse = proceedResponse {
+                completion?(.success(proceedResponse))
+            } else if let proceedError = proceedError {
+                completion?(.failure(proceedError))
+            }
         }
     }
 }


### PR DESCRIPTION
For future-proofing of the Swift APIs, the Swift SDK is introducing support for the Result enum type as the response argument for all public asynchronous API calls. For Objective-C compatibility, standard response/error tuple completion handlers are supported as well.