### PR TITLE
Introduce a convenience property list initializer, to align with OktaOAuth2 flows

### DIFF
--- a/Documentation/OIE Migration.md
+++ b/Documentation/OIE Migration.md
@@ -10,14 +10,14 @@ For specific suggestions on how to implement the various capabilities that `okta
 ### Configuring and initializing your client
 
 ```swift
-let config = IDXClient.Configuration(
+let flow = InteractionCodeFlow(
     issuer: "https://{yourOktaDomain}/oauth2/default",
     clientId: "clientId",
     clientSecret: nil,
     scopes: ["openid", "email", "offline_access"],
     redirectUri: "com.myapp:/redirect/uri")
     
-IDXClient.start(configuration: config) { result in
+flow.start() { result in
     switch result {
     case .failure(let error):
         // Handle the error

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ When a remediation is selected and its inputs have been supplied by the user, th
 
 The below code snippets will help you understand how to use this library.
 
-Once you initialize an `IDXClient`, you can call methods to make requests to the Okta IDX API. Please see the [configuration reference](#configuration-reference) section for more details.
+Once you initialize an `InteractionCodeFlow`, you can call methods to make requests to the Okta IDX API. Please see the [configuration reference](#configuration-reference) section for more details.
 
 ### Create the flow
 
@@ -98,6 +98,12 @@ let flow = InteractionCodeFlow(
     clientId: "<#clientId#>",
     scopes: ["openid", "email", "offline_access", "<#otherScopes#>"],
     redirectUri: "<#redirectUri#>") // Must match the redirect uri in client app settings/console
+```
+
+Alternatively, if you define an `Okta.plist` configuration file within your application, you can use the default initializer to create a flow using that configuration.
+
+```swift
+let flow = try InteractionCodeFlow()
 ```
 
 > **Note:** While your issuer URL may vary for advanced configurations, for most uses it will be your Okta Domain, followed by `/oauth2/default`.

--- a/Samples/EmbeddedAuthWithSDKs/EmbeddedAuth/Signin/View Controllers/IDXStartViewController.swift
+++ b/Samples/EmbeddedAuthWithSDKs/EmbeddedAuth/Signin/View Controllers/IDXStartViewController.swift
@@ -13,7 +13,7 @@
 import UIKit
 import OktaIdx
 
-/// Sign in controller used when initializing the signin process. This encapsulates the `IDXClient.start()` API call.
+/// Sign in controller used when initializing the signin process. This encapsulates the `InteractionCodeFlow.start()` API call.
 class IDXStartViewController: UIViewController, IDXSigninController {
     var signin: Signin?
 

--- a/Sources/OktaIdx/IDXFormField.swift
+++ b/Sources/OktaIdx/IDXFormField.swift
@@ -18,7 +18,14 @@ extension Remediation.Form {
     ///
     /// Nested form values can be accessed through keyed subscripting, for example:
     ///
-    ///    credentials.form["passcode"]
+    /// ```swift
+    /// remediation.form["identifier"]
+    /// ```
+    ///
+    /// > Note: This keyed subscripting is made available through the parent ``Remediation`` object. So the above example is equally expressed as the following:
+    /// > ```swift
+    /// > remediation["identifier"]
+    /// > ```
     public final class Field: NSObject {
         /// The programmatic name for this form value.
         public let name: String?

--- a/Sources/OktaIdx/InteractionCodeFlow.swift
+++ b/Sources/OktaIdx/InteractionCodeFlow.swift
@@ -106,6 +106,29 @@ public final class InteractionCodeFlow: AuthenticationFlow {
         client.add(delegate: self)
     }
     
+    /// Initializer that uses the configuration defined within the application's `Okta.plist` file.
+    public convenience init() throws {
+        try self.init(try .init())
+    }
+    
+    /// Initializer that uses the configuration defined within the given file URL.
+    /// - Parameter fileURL: File URL to a `plist` containing client configuration.
+    public convenience init(plist fileURL: URL) throws {
+        try self.init(try .init(plist: fileURL))
+    }
+    
+    private convenience init(_ config: OAuth2Client.PropertyListConfiguration) throws {
+        guard let redirectUri = config.redirectUri else {
+            throw OAuth2Client.PropertyListConfigurationError.missingConfigurationValues
+        }
+
+        self.init(issuer: config.issuer,
+                  clientId: config.clientId,
+                  scopes: config.scopes,
+                  redirectUri: redirectUri,
+                  additionalParameters: config.additionalParameters)
+    }
+    
     /// Starts a new authentication session. If the client is able to successfully interact with Okta Identity Engine, a ``context-swift.property`` is assigned, and the initial ``Response`` is returned.
     /// - Parameters:
     ///   - options: Options to include within the OAuth2 transaction.


### PR DESCRIPTION
I discovered, while documenting the authentication flows, that InteractionCodeFlow didn't consume the default Okta.plist file, as in other authentication flows.