### PR TITLE
Introduce deprecation warnings to assist in migrating from OktaIdx 2.x

### DIFF
--- a/Sources/OktaIdx/Extensions/DeprecationWarnings.swift
+++ b/Sources/OktaIdx/Extensions/DeprecationWarnings.swift
@@ -1,0 +1,46 @@
+//
+// Copyright (c) 2022-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import Foundation
+
+@available (*, unavailable, renamed: "InteractionCodeFlow")
+public struct IDXClient {
+    @available (*, unavailable)
+    public struct Configuration {
+        @available (*, unavailable)
+        public init(issuer: String,
+                    clientId: String,
+                    clientSecret: String?,
+                    scopes: [String],
+                    redirectUri: String) {}
+    }
+    
+    @available (*, unavailable)
+    public enum Option: Hashable {}
+    
+    @available (*, unavailable,
+                 renamed: "start(options:completion:)",
+                 message: "IDXClient replaced with InteractionCodeFlow")
+    public static func start(with configuration: Any,
+                             options: [Option:String]? = nil,
+                             completion: @escaping (Result<IDXClient, Error>) -> Void) {}
+    
+    @available (*, unavailable,
+                 renamed: "start(options:completion:)",
+                 message: "IDXClient replaced with InteractionCodeFlow")
+    public static func start(with configuration: Configuration,
+                             options: [String:String]? = nil,
+                             completion: @escaping (_ client: IDXClient?, _ error: Error?) -> Void) {}
+    
+    @available (*, unavailable)
+    public func resume(completion: ((Result<Response, Error>) -> Void)?) {}
+}

--- a/Sources/OktaIdx/Extensions/DeprecationWarnings.swift
+++ b/Sources/OktaIdx/Extensions/DeprecationWarnings.swift
@@ -31,14 +31,14 @@ public struct IDXClient {
                  renamed: "start(options:completion:)",
                  message: "IDXClient replaced with InteractionCodeFlow")
     public static func start(with configuration: Any,
-                             options: [Option:String]? = nil,
+                             options: [Option: String]? = nil,
                              completion: @escaping (Result<IDXClient, Error>) -> Void) {}
     
     @available (*, unavailable,
                  renamed: "start(options:completion:)",
                  message: "IDXClient replaced with InteractionCodeFlow")
     public static func start(with configuration: Configuration,
-                             options: [String:String]? = nil,
+                             options: [String: String]? = nil,
                              completion: @escaping (_ client: IDXClient?, _ error: Error?) -> Void) {}
     
     @available (*, unavailable)

--- a/Sources/OktaIdx/OktaIdx.docc/OktaIdx.md
+++ b/Sources/OktaIdx/OktaIdx.docc/OktaIdx.md
@@ -7,6 +7,7 @@ Authenticate users using policy-driven native authentication with the Okta Ident
 ### Essentials
 
 - ``InteractionCodeFlow``
+- ``InteractionCodeFlowDelegate``
 - ``Response``
 - ``Remediation``
 
@@ -35,6 +36,7 @@ Authenticate users using policy-driven native authentication with the Okta Ident
 
 - ``Capability``
 - ``CapabilityCollection``
+- ``IDXCapability``
 - ``AuthenticatorCapability``
 - ``RemediationCapability``
 - ``Capability/NumberChallenge``
@@ -46,3 +48,12 @@ Authenticate users using policy-driven native authentication with the Okta Ident
 - ``Capability/Resendable``
 - ``Capability/SocialIDP``
 - ``Capability/OTP``
+
+### Errors
+
+- ``IDXServerError``
+- ``InteractionCodeFlowError``
+
+### Deprecations
+
+- ``IDXClient``


### PR DESCRIPTION
Note: I can't see a decent way to unit test the unavailability of certain APIs without causing the test runner to blow up.