### PR TITLE
Add optional user profile information to responses

### DIFF
--- a/Sources/OktaIdx/IDXUser.swift
+++ b/Sources/OktaIdx/IDXUser.swift
@@ -17,5 +17,32 @@ extension Response {
     public struct User {
         /// Unique identifier for this user.
         public let id: String
+        
+        /// Username for this user.
+        ///
+        /// This value may not be available at all times.
+        public let username: String?
+        
+        /// Profile information for this user.
+        ///
+        /// This value may not be available at all times.
+        public let profile: Profile?
+    }
+}
+
+extension Response.User {
+    /// Optional profile information that describes the user.
+    public struct Profile {
+        /// The user's first name.
+        public let firstName: String?
+        
+        /// The user's last name.
+        public let lastName: String?
+        
+        /// The user's time zone.
+        public let timeZone: TimeZone?
+        
+        /// The user's locale.
+        public let locale: Locale?
     }
 }

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Responses/IDXClient+V1ResponseConstructors.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Responses/IDXClient+V1ResponseConstructors.swift
@@ -63,7 +63,7 @@ extension Response.User {
 }
 
 extension Response.User.Profile {
-    internal init?(ion object: [String:String]?) {
+    internal init?(ion object: [String: String]?) {
         guard let object = object else { return nil }
 
         var timeZone: TimeZone?

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Responses/IDXClient+V1ResponseConstructors.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Responses/IDXClient+V1ResponseConstructors.swift
@@ -58,9 +58,31 @@ extension Response.User {
         guard let object = object,
               let userId = object.id
         else { return nil }
-        self.init(id: userId)
+        self.init(id: userId, username: object.identifier, profile: .init(ion: object.profile))
     }
 }
+
+extension Response.User.Profile {
+    internal init?(ion object: [String:String]?) {
+        guard let object = object else { return nil }
+
+        var timeZone: TimeZone?
+        if let string = object["timeZone"] {
+            timeZone = TimeZone(identifier: string)
+        }
+
+        var locale: Locale?
+        if let string = object["locale"] {
+            locale = Locale(identifier: string)
+        }
+
+        self.init(firstName: object["firstName"],
+                  lastName: object["lastName"],
+                  timeZone: timeZone,
+                  locale: locale)
+    }
+}
+
 
 extension IonResponse {
     struct AuthenticatorMapping {

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Responses/Responses.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Responses/Responses.swift
@@ -78,7 +78,7 @@ struct IonCollection<T>: Decodable where T: Decodable {
 
 struct IonUser: Decodable, ReceivesIDXResponse {
     let id: String?
-    let profile: [String:String]?
+    let profile: [String: String]?
     let identifier: String?
 }
 

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Responses/Responses.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Responses/Responses.swift
@@ -78,6 +78,8 @@ struct IonCollection<T>: Decodable where T: Decodable {
 
 struct IonUser: Decodable, ReceivesIDXResponse {
     let id: String?
+    let profile: [String:String]?
+    let identifier: String?
 }
 
 struct IonApp: Decodable, ReceivesIDXResponse {

--- a/Tests/OktaIdxTests/IDXClientV1ResponseTests.swift
+++ b/Tests/OktaIdxTests/IDXClientV1ResponseTests.swift
@@ -475,7 +475,7 @@ class IDXClientV1ResponseTests: XCTestCase {
         XCTAssertEqual(publicObj?.name, "client")
     }
 
-    func testUser() throws {
+    func testSimpleUser() throws {
         let obj = try decode(type: IonObject<IonUser>.self, """
            {
               "type" : "object",
@@ -492,6 +492,42 @@ class IDXClientV1ResponseTests: XCTestCase {
         let publicObj = Response.User(ion: obj.value)
         XCTAssertNotNil(publicObj)
         XCTAssertEqual(publicObj?.id, "0ZczewGCFPlxNYYcLq5i")
+    }
+
+    func testUserProfile() throws {
+        let obj = try decode(type: IonObject<IonUser>.self, """
+           {
+               "type" : "object",
+               "value" : {
+                 "id" : "0ZczewGCFPlxNYYcLq5i",
+                 "profile" : {
+                   "firstName": "Arthur",
+                   "lastName": "Dent",
+                   "timeZone": "America/Los_Angeles",
+                   "locale": "en_US"
+                 },
+                 "identifier" : "arthur.dent@example.com"
+               }
+           }
+        """)
+        
+        XCTAssertNotNil(obj)
+        XCTAssertEqual(obj.type, "object")
+        XCTAssertEqual(obj.value.id, "0ZczewGCFPlxNYYcLq5i")
+        XCTAssertEqual(obj.value.profile?.keys.sorted(), ["firstName", "lastName", "locale", "timeZone"])
+        XCTAssertEqual(obj.value.profile?["firstName"], "Arthur")
+        XCTAssertEqual(obj.value.profile?["lastName"], "Dent")
+        XCTAssertEqual(obj.value.profile?["lastName"], "Dent")
+        XCTAssertEqual(obj.value.identifier, "arthur.dent@example.com")
+
+        let publicObj = Response.User(ion: obj.value)
+        XCTAssertNotNil(publicObj)
+        XCTAssertEqual(publicObj?.id, "0ZczewGCFPlxNYYcLq5i")
+        XCTAssertEqual(publicObj?.profile?.firstName, "Arthur")
+        XCTAssertEqual(publicObj?.profile?.lastName, "Dent")
+        XCTAssertEqual(publicObj?.profile?.timeZone?.identifier, "America/Los_Angeles")
+        XCTAssertEqual(publicObj?.profile?.locale?.identifier, "en_US")
+        XCTAssertEqual(publicObj?.username, "arthur.dent@example.com")
     }
 
     func testPasswordAuthenticatorWithSettings() throws {


### PR DESCRIPTION
The structure of user responses now includes additional information pulled from the ID Token which can assist UI developers in providing further context about who the user is that is authenticating.