### PR TITLE
Make sending the Device Token configurable, and bump the upstream dependency version

### DIFF
--- a/OktaIdx.podspec
+++ b/OktaIdx.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'OktaIdx'
-  spec.version          = '3.0.4'
+  spec.version          = '3.0.5'
   spec.summary          = 'SDK to easily integrate the Okta Identity Engine'
   spec.description      = <<-DESC
 Integrate your native app with Okta using the Okta Identity Engine library.
@@ -24,5 +24,5 @@ Integrate your native app with Okta using the Okta Identity Engine library.
   spec.source_files = 'Sources/OktaIdx/**/*.swift'
   spec.swift_version = "5.5"
 
-  spec.dependency "OktaAuthFoundation", "1.1.4"
+  spec.dependency "OktaAuthFoundation", "~> 1.1"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ var package = Package(
     dependencies: [
         .package(name: "AuthFoundation",
                  url: "https://github.com/okta/okta-mobile-swift",
-                 from: "1.1.4")
+                 from: "1.1.5")
     ],
     targets: [
         .target(name: "OktaIdx",

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This library uses semantic versioning and follows Okta's [Library Version Policy
 | ------- | ---------------------------------- |
 | 1.0.0   |                                    |
 | 2.0.1   |                                    |
-| 3.0.4   | ✔️ Stable                           |
+| 3.0.5   | ✔️ Stable                           |
 
 The latest release can always be found on the [releases page][github-releases].
 

--- a/Sources/OktaIdx/Extensions/InteractionCodeFlow+DeviceIdentifier.swift
+++ b/Sources/OktaIdx/Extensions/InteractionCodeFlow+DeviceIdentifier.swift
@@ -80,3 +80,12 @@ extension InteractionCodeFlow {
         return deviceToken
     }
 }
+
+extension InteractionCodeFlow.Option {
+    var includeInInteractRequest: Bool {
+        switch self {
+        case .omitDeviceToken: return false
+        default: return true
+        }
+    }
+}

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Requests/InteractRequest.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Requests/InteractRequest.swift
@@ -19,14 +19,14 @@ extension InteractionCodeFlow {
         let clientId: String
         let scope: String
         let redirectUri: URL
-        let options: [InteractionCodeFlow.Option: String]?
+        let options: [InteractionCodeFlow.Option: Any]?
         let pkce: PKCE
 
         init(baseURL: URL,
              clientId: String,
              scope: String,
              redirectUri: URL,
-             options: [InteractionCodeFlow.Option: String]?,
+             options: [InteractionCodeFlow.Option: Any]?,
              pkce: PKCE)
         {
             url = baseURL.appendingPathComponent("v1/interact")
@@ -59,10 +59,12 @@ extension InteractionCodeFlow.InteractRequest: APIRequest, APIRequestBody {
             "code_challenge_method": pkce.method.rawValue
         ]
         
-        options?.forEach { (key: InteractionCodeFlow.Option, value: String) in
-            result[key.rawValue] = value
-        }
-        
+        options?.filter { $0.key.includeInInteractRequest }
+            .compactMapValues { $0 as? String }
+            .forEach { (key: InteractionCodeFlow.Option, value: String) in
+                result[key.rawValue] = value
+            }
+
         return result
     }
 }

--- a/Sources/OktaIdx/Version.swift
+++ b/Sources/OktaIdx/Version.swift
@@ -12,4 +12,4 @@
 
 import Foundation
 
-public let Version = SDKVersion(sdk: "okta-idx-swift", version: "3.0.4")
+public let Version = SDKVersion(sdk: "okta-idx-swift", version: "3.0.5")

--- a/Tests/OktaIdxTests/InteractionCodeFlowTests.swift
+++ b/Tests/OktaIdxTests/InteractionCodeFlowTests.swift
@@ -76,6 +76,38 @@ class InteractionCodeFlowTests: XCTestCase {
 
         XCTAssertEqual(delegate.calls.count, 1)
         XCTAssertEqual(delegate.calls.first?.type, .response)
+        
+        let deviceToken = try XCTUnwrap(flow.deviceTokenCookie?.value)
+        XCTAssertEqual(urlSession.requests.first?.allHTTPHeaderFields?["Cookie"],
+                       "DT=\(deviceToken)")
+    }
+    
+    func testStartWithOptions() throws {
+        urlSession.expect("https://example.com/oauth2/default/v1/interact",
+                          data: try data(from: .module,
+                                         for: "interact-response"))
+        urlSession.expect("https://example.com/idp/idx/introspect",
+                          data: try data(from: .module,
+                                         for: "introspect-response"))
+        
+        let wait = expectation(description: "start")
+        flow.start(options: [
+            .omitDeviceToken: true,
+            .state: "CustomState"
+        ]) { result in
+            defer { wait.fulfill() }
+            
+            guard case let Result.success(response) = result else {
+                XCTFail("Received a failure when a success was expected")
+                return
+            }
+            
+            XCTAssertNotNil(response.remediations[.identify])
+        }
+        waitForExpectations(timeout: 1.0)
+        
+        XCTAssertNil(urlSession.requests.first?.allHTTPHeaderFields?["Cookie"])
+        XCTAssertEqual(flow.context?.state, "CustomState")
     }
 
     func testStartFailedInteract() throws {

--- a/Tests/OktaIdxTests/InteractionCodeFlowTests.swift
+++ b/Tests/OktaIdxTests/InteractionCodeFlowTests.swift
@@ -77,9 +77,11 @@ class InteractionCodeFlowTests: XCTestCase {
         XCTAssertEqual(delegate.calls.count, 1)
         XCTAssertEqual(delegate.calls.first?.type, .response)
         
-        let deviceToken = try XCTUnwrap(flow.deviceTokenCookie?.value)
-        XCTAssertEqual(urlSession.requests.first?.allHTTPHeaderFields?["Cookie"],
-                       "DT=\(deviceToken)")
+        if InteractionCodeFlow.deviceIdentifier != nil {
+            let deviceToken = try XCTUnwrap(flow.deviceTokenCookie?.value)
+            XCTAssertEqual(urlSession.requests.first?.allHTTPHeaderFields?["Cookie"],
+                           "DT=\(deviceToken)")
+        }
     }
     
     func testStartWithOptions() throws {


### PR DESCRIPTION
This also includes improvements to the sample application, to make it easier to reset / remove credentials when the account is invalid.