### PR TITLE
Ensure null name values within a nonnull User.Profile are handled properly

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -32,8 +32,6 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_13.3.app/Contents/Developer
     steps:
-    - name: Get swift version
-      run: swift --version
     - uses: actions/checkout@master
     - name: Build
       run: swift build --build-tests

--- a/OktaIdx.podspec
+++ b/OktaIdx.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'OktaIdx'
-  spec.version          = '3.0.6'
+  spec.version          = '3.0.7'
   spec.summary          = 'SDK to easily integrate the Okta Identity Engine'
   spec.description      = <<-DESC
 Integrate your native app with Okta using the Okta Identity Engine library.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This library uses semantic versioning and follows Okta's [Library Version Policy
 | ------- | ---------------------------------- |
 | 1.0.0   |                                    |
 | 2.0.1   |                                    |
-| 3.0.6   | ✔️ Stable                           |
+| 3.0.7   | ✔️ Stable                           |
 
 The latest release can always be found on the [releases page][github-releases].
 

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Responses/IDXClient+V1ResponseConstructors.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Responses/IDXClient+V1ResponseConstructors.swift
@@ -58,7 +58,9 @@ extension Response.User {
         guard let object = object,
               let userId = object.id
         else { return nil }
-        self.init(id: userId, username: object.identifier, profile: .init(ion: object.profile))
+        self.init(id: userId,
+                  username: object.identifier,
+                  profile: .init(ion: object.profile?.compactMapValues({ $0 })))
     }
 }
 

--- a/Sources/OktaIdx/Internal/Implementations/Version1/Responses/Responses.swift
+++ b/Sources/OktaIdx/Internal/Implementations/Version1/Responses/Responses.swift
@@ -78,7 +78,7 @@ struct IonCollection<T>: Decodable where T: Decodable {
 
 struct IonUser: Decodable, ReceivesIDXResponse {
     let id: String?
-    let profile: [String: String]?
+    let profile: [String: String?]?
     let identifier: String?
 }
 

--- a/Sources/OktaIdx/Version.swift
+++ b/Sources/OktaIdx/Version.swift
@@ -12,4 +12,4 @@
 
 import Foundation
 
-public let Version = SDKVersion(sdk: "okta-idx-swift", version: "3.0.6")
+public let Version = SDKVersion(sdk: "okta-idx-swift", version: "3.0.7")

--- a/Tests/OktaIdxTests/IDXClientV1ResponseTests.swift
+++ b/Tests/OktaIdxTests/IDXClientV1ResponseTests.swift
@@ -530,6 +530,29 @@ class IDXClientV1ResponseTests: XCTestCase {
         XCTAssertEqual(publicObj?.username, "arthur.dent@example.com")
     }
 
+    func testNullUserProfile() throws {
+        let obj = try decode(type: IonObject<IonUser>.self, """
+           {
+               "type" : "object",
+               "value" : {
+                 "id" : "0ZczewGCFPlxNYYcLq5i",
+                 "profile" : {
+                   "firstName": null,
+                   "lastName": null,
+                   "timeZone": "America/Los_Angeles",
+                   "locale": "en_US"
+                 },
+                 "identifier" : "arthur.dent@example.com"
+               }
+           }
+        """)
+        
+        let publicObj = Response.User(ion: obj.value)
+        XCTAssertNotNil(publicObj)
+        XCTAssertNil(publicObj?.profile?.firstName)
+        XCTAssertNil(publicObj?.profile?.lastName)
+    }
+
     func testPasswordAuthenticatorWithSettings() throws {
         let obj = try decode(type: IonObject<IonAuthenticator>.self, """
         {


### PR DESCRIPTION
This is in response to #121 where a user profile object is supplied with explicit null firstName/lastName values.