### PR TITLE
Introduce an interactive Playground to demonstrate how to use OktaIdx

### DIFF
--- a/OktaIdx.xcworkspace/contents.xcworkspacedata
+++ b/OktaIdx.xcworkspace/contents.xcworkspacedata
@@ -5,13 +5,13 @@
       location = "group:">
    </FileRef>
    <Group
-      location = "container:"
+      location = "container:Samples"
       name = "Samples">
       <FileRef
-         location = "group:Samples/EmbeddedAuthWithSDKs/EmbeddedAuth.xcodeproj">
+         location = "group:EmbeddedAuthWithSDKs/EmbeddedAuth.xcodeproj">
       </FileRef>
       <Group
-         location = "group:Samples/Signin Samples"
+         location = "group:Signin Samples"
          name = "Signin Samples">
          <FileRef
             location = "group:BasicLogin.swift">
@@ -23,5 +23,8 @@
             location = "group:MultifactorLogin.swift">
          </FileRef>
       </Group>
+      <FileRef
+         location = "group:Sample Playground.playground">
+      </FileRef>
    </Group>
 </Workspace>

--- a/Samples/Sample Playground.playground/Pages/Basic Sign In.xcplaygroundpage/Contents.swift
+++ b/Samples/Sample Playground.playground/Pages/Basic Sign In.xcplaygroundpage/Contents.swift
@@ -1,0 +1,116 @@
+/*:
+ [Previous](@previous)
+
+ # Basic Sign In with Username and Password
+
+ To introduce you to the basics of authenticating using OktaIdx, we'll start with a simple username / password flow. This will allow us to introduce a few key concepts, while keeping the code simple.
+ 
+ - Note:
+   Simple username and password authentication doesn't need the full power of OktaIdx, but it is a useful way to demonstrate a simple flow.
+   \
+   \
+   If you do not intend to implement MFA functionality, you can use the [Resource Owner Flow](https://okta.github.io/okta-mobile-swift/development/oktaoauth2/documentation/oktaoauth2/resourceownerflow) within the [okta-mobile-swift](https://github.com/okta/okta-mobile-swift) SDK.
+ 
+ This workflow will demonstrate filling out two separate remediations (`.identify`, and `.challengeAuthenticator`), and finally exchanging a successful response for a token.
+ 
+ With that out of the way, lets try our sample code. To start, we'll get some Playgrounds housekeeping out of the way.
+ */
+import Foundation
+import PlaygroundSupport
+PlaygroundPage.current.needsIndefiniteExecution = true
+/*:
+ ## Configure the authentication flow
+ We'll start by creating an instance of the [InteractionCodeFlow](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/interactioncodeflow) class, which will be used to interact with Okta to perform the sign in operation.
+ 
+ Update the placeholder values below with the settings in your Okta Admin dashboard.
+ */
+import OktaIdx
+
+let flow = InteractionCodeFlow(issuer: URL(string: "https://<#domain#>/oauth2/default")!,
+                               clientId: "<#client_id#>",
+                               scopes: "openid profile offline_access",
+                               redirectUri: URL(string: "<#redirect_uri#>")!)
+let username = "<#username#>"
+let password = "<#password#>"
+
+/*:
+ We'll also define an error type to represent the various errors we can expect to encounter.
+ */
+public enum LoginError: Error {
+    case error(_ error: Error)
+    case message(_ string: String)
+    case cannotProceed
+    case unexpectedAuthenticator
+    case unknown
+}
+
+/*:
+ Since the login function is asynchronous, we'll wrap the call in a Task, to allow the Playground page to continue. Your implementation may vary.
+ */
+Task {
+    do {
+/*:
+ ## Step through each response in the flow
+ To start authentication, we need to get the first initial response. This usually is a prompt to input the user's identifier (username), and depending on policy settings, may also include a field for the user's password.
+ 
+ We plan to step through multiple responses, so we're making this a `var` variable.
+ */
+var response = try await flow.start()
+//: At this point, we loop over each form response, until we successfully sign in.
+while !response.isLoginSuccessful {
+//: We'll start checking each response at the beginning to see if any error messages are returned, report them and abort the process.  Under normal circumstances we might want to present these errors to the user, since some messages are actionable by the user.
+    if let message = response.messages.allMessages.first {
+        throw LoginError.message(message.message)
+    }
+/*:
+ We then try to find the remediation asking for the user's identifier, and supply the user's username to the appropriate field.
+ 
+ Sometimes the form allows the password to be supplied in the same remediation, so we should also try to pass that along to the passcode field.
+ 
+ With those values filled out, we can call [proceed](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/remediation/proceed()) to submit the form, proceeding to the next response in the flow.
+ */
+    if let remediation = response.remediations[.identify],
+       let usernameField = remediation["identifier"]
+    {
+        usernameField.value = username
+        remediation["credentials.passcode"]?.value = password
+        response = try await remediation.proceed()
+    }
+//: If the current form doesn't have the `identifier` remediation, we'll try to find the password authenticator challenge remediation, which is used to supply the user's password.
+    else if let remediation = response.remediations[.challengeAuthenticator],
+            let passwordField = remediation["credentials.passcode"]
+    {
+//: We'll check to make sure the user is being prompted to challenge the "password" authenticator, since this may instead be prompting to challenge some other authenticator method (e.g. email, phone, security question, etc).
+        guard remediation.authenticators.contains(where: { $0.type == .password })
+        else {
+            throw LoginError.unexpectedAuthenticator
+        }
+//: Supply the user's password to the field and proceed through the remediation to receive the next form.
+        passwordField.value = password
+        response = try await remediation.proceed()
+    }
+//: Finally, we'll check to see if we have received a remediation we don't expect. This can be an extension point for your application, to support other stages in the authentication flow.
+    else {
+        throw LoginError.cannotProceed
+    }
+}
+/*:
+ ## Retrieving a token
+Finally, if we've made it this far, we know we have a successful response. At this point, we can exchange the this response with a token.
+ */
+let token = try await response.exchangeCode()
+//: Once we receive the token, we can either use its values directly, or we can store it for later use using the ``Credential`` class.
+    print("Received token \(token.accessToken)")
+/*:
+ ## Wrapping up
+ At this point we can wrap up the Playground page to catch and report errors, and to finish the current page's execution.
+ */
+} catch {
+    print(error)
+}
+    
+    PlaygroundPage.current.finishExecution()
+}
+/*:
+ Now that we've demonstrated a simple sign in flow, lets move on to a more complicated example on the [next page](@next).
+ */

--- a/Samples/Sample Playground.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
+++ b/Samples/Sample Playground.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
@@ -1,0 +1,25 @@
+/*:
+ # Table of Contents
+ * [Basic Sign In with Username and Password](Basic%20Sign%20In)
+ * [Social Sign In using an IDP](Social%20Sign%20In)
+ * [Self-Service Registration](Self-Service%20Registration)
+
+ # Overview
+ 
+ This collection of Playgrounds intends to demonstrate a few workflows you can use to get started using OktaIdx.
+ 
+ The [OktaIdx API documentation](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/) is available on Github, so we encourage you to find more information there.
+ 
+ - Note:
+   Due to peculiarities of Xcode Playgrounds, this page will follow some more simplistic options here.
+   \
+   \
+   For a complete working example, please see the `Samples/Signin Samples/MultifactorLogin.swift` file. Our examples within this Playground follow an imperative workflow, making assumptions about the options and order of the remediations reterned.
+   \
+   \
+   These examples will use Swift Concurrency `async` / `await`.
+ 
+ OktaIdx follows a call/response model, where a `Response` contains information about the next steps (or "Remediations") a user may take to authenticate. These options may ask the user to identify themselves (e.g. enter a username), to challenge an authenticator (enter a password or SMS/Email verification code), to make a choice as to which authenticator they want to use, and many other steps. These remediations contain form fields that are used to prompt the user for required information. Additionally, authenticators may be associated with a remediation or a particular field, which provides additional details about the actions a user can take.
+ 
+ To continue, please [proceed to the next page](@next).
+ */

--- a/Samples/Sample Playground.playground/Pages/Self-Service Registration.xcplaygroundpage/Contents.swift
+++ b/Samples/Sample Playground.playground/Pages/Self-Service Registration.xcplaygroundpage/Contents.swift
@@ -1,0 +1,128 @@
+/*:
+ [Previous](@previous)
+
+ # Self-Service Registration
+
+ The [Basic Sign In](Basic%20Sign%20In) example showed how to identify the user and supply a password. However, if self service registration is enabled in the application's policy settings, the additional remediation `.selectEnrollProfile` is made available to the user.
+
+ The "Select Enroll Profile" represents a "Sign Up" link on the form. Proceeding through this remediation will return the `.enrollProfile` remediation, which allows the user to fill in their profile details.
+ 
+ This example will walk through those options.
+ 
+ - Note:
+   The purpose of this example is to demonstrate how to use the API, though in a real-world application it should not make assumptions about the presence of these remediations, and should give the user options to perform different available operations.
+
+ With that out of the way, lets try our sample code. To start, we'll get some Playgrounds housekeeping out of the way.
+ */
+import Foundation
+import PlaygroundSupport
+PlaygroundPage.current.needsIndefiniteExecution = true
+/*:
+ ## Configure the authentication flow
+ We'll start by creating an instance of the [InteractionCodeFlow](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/interactioncodeflow) class, which will be used to interact with Okta to perform the sign in operation.
+ 
+ Update the placeholder values below with the settings in your Okta Admin dashboard.
+ */
+import OktaIdx
+
+let flow = InteractionCodeFlow(issuer: URL(string: "https://<#domain#>/oauth2/default")!,
+                               clientId: "<#client_id#>",
+                               scopes: "openid profile offline_access",
+                               redirectUri: URL(string: "<#redirect_uri#>")!)
+/*:
+ We'll also define the user's profile values to be sent in the registration form.
+ 
+ - Note:
+   Ideally the fields within the registration remediation would be dynamically displayed to the user, but for the purposes of this example, we'll hard-code the fields.
+ */
+let profile = ["email": "jane.doe@example.com",
+               "firstName": "Jane",
+               "lastName": "Doe"]
+let password = "MySecretPassword"
+
+/*:
+ We'll also define an error type to represent the various errors we can expect to encounter.
+ */
+public enum LoginError: Error {
+    case error(_ error: Error)
+    case message(_ string: String)
+    case missingProfile(field: String)
+    case cannotProceed
+    case unexpectedAuthenticator
+    case unknown
+}
+/*:
+ As in our previous examples, we'll wrap the call in a Task, to allow the Playground page to continue.
+ */
+Task {
+    do {
+/*:
+ ## Receive the first response
+ To start authentication, we need to get the first initial response. In this case, since we're registering the user, we're looking for a particular remediation.
+ */
+var response = try await flow.start()
+/*:
+ ## Selecting the Enroll Profile option
+ We start registration by selecting the `.selectEnrollProfile` remediation.
+ */
+if let remediation = response.remediations[.selectEnrollProfile] {
+    response = try await remediation.proceed()
+}
+
+//: Once we receive the `.enrollProfile` remediation, we populate its fields with the values supplied by the user. Then, when all the fields are filled, we proceed through the remediation.
+if let remediation = response.remediations[.enrollProfile] {
+    for field in remediation.form.fields {
+        guard let name = field.name else { continue }
+        if let value = profile[name] {
+            field.value = value
+        } else if field.isRequired {
+            // A required profile field was not supplied
+            throw LoginError.missingProfile(field: name)
+        }
+    }
+    response = try await remediation.proceed()
+}
+/*:
+ ## Choosing a password
+ After submitting the user's profile information, the user is prompted to choose a password. This uses the `.enrollAuthenticator` remediation.
+ 
+ - Note:
+   Depending on the app's sign on policy, the user may be prompted to supply their password within the `.enrollProfile` remediation.
+ */
+if let remediation = response.remediations[.enrollAuthenticator],
+   let passwordField = remediation["credentials.passcode"]
+{
+//: We'll check to make sure the user is being prompted to challenge the "password" authenticator, since this may instead be prompting to challenge some other authenticator method (e.g. email, phone, security question, etc).
+    guard remediation.authenticators.contains(where: { $0.type == .password })
+    else {
+        throw LoginError.unexpectedAuthenticator
+    }
+//: Supply the user's password to the field and proceed through the remediation to receive the next form.
+    passwordField.value = password
+    response = try await remediation.proceed()
+}
+/*:
+ ## Retrieving a token
+ Finally, if we've made it this far, we'll assume we have a successful response. At this point, we can exchange the this response with a token.
+ 
+ - Note:
+   For the purposes of this sample, we'll assume that no additional MFA authenticators require enrolment. If your app's policy is set to require more than one factor, this code will not work.
+*/
+guard response.isLoginSuccessful else {
+    throw LoginError.cannotProceed
+}
+
+let token = try await response.exchangeCode()
+//: Once we receive the token, we can either use its values directly, or we can store it for later use using the ``Credential`` class.
+print("Received token \(token.accessToken)")
+/*:
+## Wrapping up
+At this point we can wrap up the Playground page to catch and report errors, and to finish the current page's execution.
+*/
+} catch {
+    print(error)
+}
+
+PlaygroundPage.current.finishExecution()
+}
+

--- a/Samples/Sample Playground.playground/Pages/Social Sign In.xcplaygroundpage/Contents.swift
+++ b/Samples/Sample Playground.playground/Pages/Social Sign In.xcplaygroundpage/Contents.swift
@@ -1,0 +1,113 @@
+/*:
+ [Previous](@previous)
+
+ # Social Sign In using an IDP
+
+ Authenticating using a social IDP is fairly straightforward. This playground page will show how to dig into the additional capabilities each remediation optionally supports.
+
+ [Authenticators](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/authenticator) and [Remediations](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/remediation) have varying types of capabilities they offer. For example, a Phone authenticator may be capable of sending, or resending, a verification code. Email authenticators may be able to poll in the background while waiting for a user to click the verification link in their email.
+ 
+ Whichever the option, these operations are described as a [Capability](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/capability). This sample therefore uses the [SocialIDP](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/capability/socialidp) capability, which exposes details about the IDP vendor, particularly the URL needed to be redirected to in order to authenticate.
+ 
+ With that out of the way, lets try our sample code. To start, we'll get some Playgrounds housekeeping out of the way.
+ */
+import UIKit
+import AuthenticationServices
+import PlaygroundSupport
+PlaygroundPage.current.needsIndefiniteExecution = true
+//: We'll also create a view controller to not only show the simulator within the playground, but also to define the presentation context for the authorization web view controller.
+let placeholderController = PlaceholderViewController()
+PlaygroundPage.current.liveView = placeholderController
+/*:
+ ## Configure the authentication flow
+ We'll start by creating an instance of the [InteractionCodeFlow](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/interactioncodeflow) class, which will be used to interact with Okta to perform the sign in operation.
+ 
+ Update the placeholder values below with the settings in your Okta Admin dashboard.
+ */
+import OktaIdx
+let flow = InteractionCodeFlow(issuer: URL(string: "https://<#domain#>/oauth2/default")!,
+                               clientId: "<#client_id#>",
+                               scopes: "openid profile offline_access",
+                               redirectUri: URL(string: "<#redirect_uri#>")!)
+//: We also want to pull out the application's redirect scheme, since this is needed by the AuthenticationServices framework.
+guard let scheme = flow.redirectUri.scheme else {
+    throw LoginError.cannotProceed
+}
+/*:
+ We'll also define an error type to represent the various errors we can expect to encounter.
+ */
+public enum LoginError: Error {
+    case error(_ error: Error)
+    case message(_ string: String)
+    case cannotProceed
+    case unexpectedAuthenticator
+    case unknown
+}
+
+/*:
+ Since the login function is asynchronous, we'll wrap the call in a Task, to allow the Playground page to continue. Your implementation may vary.
+ */
+Task {
+    do {
+/*:
+ ## Find the Social IDP capability
+ To start authentication, we need to get the first initial response. This usually is a prompt to input the user's identifier (username), or to sign in using one of several Social IDPs.
+ */
+let response = try await flow.start()
+
+//: We then dig through the remediations, finding the remediation that matches the Social IDP we're interested in, and pulling out its capability object for later use.
+guard let remediation = response.remediations.first(where: { $0.socialIdp?.service == .facebook }),
+      let capability = remediation.socialIdp
+else {
+    throw LoginError.cannotProceed
+}
+/*:
+ ## Presenting the Social IDP web URL
+ Signing in with an IDP functions similarly to standard OIDC sign in flows. We need to present the [redirectUrl](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/capability/socialidp/redirecturl) to the user using an instance of `ASWebAuthenticationSession`. When the browser redirects to our own client application's scheme, we can then exchange that callback URL with Okta tokens.
+ */
+let callbackUrl: URL = try await withCheckedThrowingContinuation { continuation in
+    // Create an ASWebAuthenticationSession to trigger the IDP OAuth2 flow.
+    let session = ASWebAuthenticationSession(url: capability.redirectUrl,
+                                             callbackURLScheme: scheme)
+    { (callbackURL, error) in
+        // Ensure no error occurred, and that the callback URL is valid.
+        guard error == nil,
+              let callbackURL = callbackURL
+        else {
+            continuation.resume(throwing: error ?? LoginError.cannotProceed)
+            return
+        }
+        
+        continuation.resume(returning: callbackURL)
+    }
+    
+    // Start and present the web authentication session.
+    session.presentationContextProvider = placeholderController
+    session.prefersEphemeralWebBrowserSession = true
+    session.start()
+}
+/*:
+ We then inspect the result of the callback URL. The [RedirectResult](https://okta.github.io/okta-idx-swift/development/oktaidx/documentation/oktaidx/interactioncodeflow/redirectresult) is used to determine what the result of the sign in was.
+ 
+ When the social login result is `authenticated`, use the flow to exchange the callback URL returned from ASWebAuthenticationSession with an Okta token.
+*/
+switch flow.redirectResult(for: callbackUrl) {
+case .authenticated:
+    let token = try await flow.exchangeCode(redirect: callbackUrl)
+    print("Received token \(token.accessToken)")
+
+default:
+    throw LoginError.cannotProceed
+}
+/*:
+## Wrapping up
+At this point we can wrap up the Playground page to catch and report errors, and to finish the current page's execution.
+*/
+    } catch {
+        print(error)
+    }
+    PlaygroundPage.current.finishExecution()
+}
+/*:
+ Now that we've demonstrated how to use Social Login, we can move onto a more complicated example in [next page](@next).
+ */

--- a/Samples/Sample Playground.playground/Pages/Social Sign In.xcplaygroundpage/Sources/PlaceholderViewController.swift
+++ b/Samples/Sample Playground.playground/Pages/Social Sign In.xcplaygroundpage/Sources/PlaceholderViewController.swift
@@ -1,0 +1,8 @@
+import UIKit
+import AuthenticationServices
+
+public class PlaceholderViewController: UIViewController, ASWebAuthenticationPresentationContextProviding {
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        view.window!
+    }
+}

--- a/Samples/Sample Playground.playground/Pages/Social Sign In.xcplaygroundpage/Sources/SocialLogin.swift
+++ b/Samples/Sample Playground.playground/Pages/Social Sign In.xcplaygroundpage/Sources/SocialLogin.swift
@@ -1,0 +1,125 @@
+//
+// Copyright (c) 2021-Present, Okta, Inc. and/or its affiliates. All rights reserved.
+// The Okta software accompanied by this notice is provided pursuant to the Apache License, Version 2.0 (the "License.")
+//
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and limitations under the License.
+//
+
+import UIKit
+import OktaIdx
+import AuthenticationServices
+
+/// This class demonstrates how implementing signin with social auth providers can be implemented.
+///
+/// The completion handler supplied to the `login` function will be invoked once, either with a fatal error, or with a token.
+///
+/// Example:
+///
+/// ```swift
+/// self.authHandler = SocialLogin(configuration: configuration)
+/// self.authHandler?.login(service: .facebook)
+/// { result in
+///     switch result {
+///     case .success(let token):
+///         print(token)
+///     case .failure(let error):
+///         print(error)
+///     }
+/// }
+/// ```
+///
+/// If you want to use a custom presentation context, you can optionally supply it to the login method.
+public class SocialLogin {
+    private let flow: InteractionCodeFlow
+
+    public init(issuer: URL,
+                clientId: String,
+                scopes: String,
+                redirectUri: URL)
+    {
+        // Initializes the flow which can be used later in the process.
+        flow = InteractionCodeFlow(issuer: issuer,
+                                   clientId: clientId,
+                                   scopes: scopes,
+                                   redirectUri: redirectUri)
+    }
+
+    /// Public function used to initiate login using a given Social Authentication service.
+    ///
+    /// Optionally, a presentation context can be supplied when presenting the ASWebAuthenticationSession instance.
+    /// - Parameters:
+    ///   - service: Social service to authenticate against.
+    ///   - presentationContext: Optional presentation context to present login from.
+    public func login(service: Capability.SocialIDP.Service,
+                      from presentationContext: ASWebAuthenticationPresentationContextProviding? = nil) async throws -> Token
+    {
+        let response = try await flow.start()
+
+        // Find the Social IDP remediation that matches the requested social auth service.
+        guard let remediation = response.remediations.first(where: { $0.socialIdp?.service == service }),
+              let capability = remediation.socialIdp
+        else {
+            throw LoginError.cannotProceed
+        }
+        
+        // Present the user with a web sign in form for the social provider,
+        // and receive the subsequent redirect URL.
+        let callbackUrl = try await login(with: capability)
+
+        // Inspect the redirect URL to deterine what the result was.
+        switch flow.redirectResult(for: callbackUrl) {
+        case .authenticated:
+            // When the social login result is `authenticated`, use the
+            // flow to exchange the callback URL returned from
+            // ASWebAuthenticationSession with an Okta token.
+            return try await flow.exchangeCode(redirect: callbackUrl)
+
+        default:
+            throw LoginError.cannotProceed
+        }
+    }
+
+    @MainActor
+    func login(with idp: Capability.SocialIDP,
+               from presentationContext: ASWebAuthenticationPresentationContextProviding? = nil) async throws -> URL {
+        // Retrieve the Redirect URL scheme from our configuration, to
+        // supply it to the ASWebAuthenticationSession instance.
+        guard let scheme = flow.redirectUri.scheme else {
+            throw LoginError.cannotProceed
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            // Create an ASWebAuthenticationSession to trigger the IDP OAuth2 flow.
+            let session = ASWebAuthenticationSession(url: idp.redirectUrl,
+                                                     callbackURLScheme: scheme)
+            { (callbackURL, error) in
+                // Ensure no error occurred, and that the callback URL is valid.
+                guard error == nil,
+                      let callbackURL = callbackURL
+                else {
+                    continuation.resume(throwing: error ?? LoginError.cannotProceed)
+                    return
+                }
+                
+                continuation.resume(returning: callbackURL)
+            }
+            
+            // Start and present the web authentication session.
+            session.presentationContextProvider = presentationContext
+            session.prefersEphemeralWebBrowserSession = true
+            session.start()
+        }
+    }
+
+    public enum LoginError: Error {
+        case error(_ error: Error)
+        case message(_ string: String)
+        case cannotProceed
+        case unknown
+    }
+}

--- a/Samples/Sample Playground.playground/contents.xcplayground
+++ b/Samples/Sample Playground.playground/contents.xcplayground
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='6.0' target-platform='ios' display-mode='rendered' buildActiveScheme='true' importAppTypes='true'>
+    <pages>
+        <page name='Introduction'/>
+        <page name='Basic Sign In'/>
+        <page name='Social Sign In'/>
+        <page name='Self-Service Registration'/>
+    </pages>
+</playground>


### PR DESCRIPTION
This uses Xcode Playgrounds to create interactive documentation, walking a developer through the basics of using the SDK. This is a compliment to the [Signin Samples](Samples/Signin%20Samples) files, but in a way that can better describe what is happening in the code.