### PR TITLE
Ensure polling can continue after a network interruption error

### DIFF
--- a/Sources/OktaIdx/Capabilities/IDXPollableCapability.swift
+++ b/Sources/OktaIdx/Capabilities/IDXPollableCapability.swift
@@ -38,12 +38,12 @@ extension Capability {
                        (serverError as NSError).domain == NSURLErrorDomain,
                        (serverError as NSError).code == NSURLErrorNetworkConnectionLost
                     {
-                        return nil
+                        return .continue(using: nil)
                     }
                     
                     completion?(.failure(error))
-                    return nil
-                    
+                    return .stop
+
                 case .success(let response):
                     // If we don't get another email authenticator back, we know the
                     // magic link was clicked, and we can proceed to the completion block.
@@ -52,10 +52,10 @@ extension Capability {
                           currentAuthenticator.type == authenticatorType
                     else {
                         completion?(.success(response))
-                        return nil
+                        return .stop
                     }
                     
-                    return nextPoll.remediation
+                    return .continue(using: nextPoll.remediation)
                 }
             }
             pollHandler = handler

--- a/Sources/OktaIdx/Internal/Utilities/PollingHandler.swift
+++ b/Sources/OktaIdx/Internal/Utilities/PollingHandler.swift
@@ -71,7 +71,7 @@ class PollingHandler {
                     self.isPolling = false
                     
                 case .continue(using: let nextPollingOption):
-                    if let nextPollingOption {
+                    if let nextPollingOption = nextPollingOption {
                         self.pollOption = nextPollingOption
                     }
                     self.nextPoll(completion: completion)

--- a/Sources/OktaIdx/Internal/Utilities/PollingHandler.swift
+++ b/Sources/OktaIdx/Internal/Utilities/PollingHandler.swift
@@ -15,6 +15,11 @@ import Foundation
 class PollingHandler {
     private(set) var isPolling: Bool = false
     internal private(set) var pollOption: Remediation
+    
+    enum PollResult {
+        case stop
+        case `continue`(using: Remediation?)
+    }
 
     init(pollOption: Remediation) {
         self.pollOption = pollOption
@@ -24,7 +29,7 @@ class PollingHandler {
         isPolling = false
     }
     
-    func start(completion: @escaping (Result<Response, InteractionCodeFlowError>) -> Remediation?) {
+    func start(completion: @escaping (Result<Response, InteractionCodeFlowError>) -> PollResult) {
         guard !isPolling else { return }
         
         isPolling = true
@@ -35,7 +40,7 @@ class PollingHandler {
         isPolling = false
     }
     
-    func nextPoll(completion: @escaping (Result<Response, InteractionCodeFlowError>) -> Remediation?) {
+    func nextPoll(completion: @escaping (Result<Response, InteractionCodeFlowError>) -> PollResult) {
         guard let refreshTime = pollOption.refresh,
               refreshTime > 0
         else {
@@ -61,11 +66,15 @@ class PollingHandler {
                     return
                 }
                 
-                if let nextPollingOption = completion(result) {
-                    self.pollOption = nextPollingOption
-                    self.nextPoll(completion: completion)
-                } else {
+                switch completion(result) {
+                case .stop:
                     self.isPolling = false
+                    
+                case .continue(using: let nextPollingOption):
+                    if let nextPollingOption {
+                        self.pollOption = nextPollingOption
+                    }
+                    self.nextPoll(completion: completion)
                 }
             }
         }

--- a/Tests/OktaIdxTests/SampleResponses/MFA-SOP/06-idx-challenge.json
+++ b/Tests/OktaIdxTests/SampleResponses/MFA-SOP/06-idx-challenge.json
@@ -75,7 +75,7 @@
             "method" : "POST",
             "name" : "poll",
             "produces" : "application/ion+json; okta-version=1.0.0",
-            "refresh" : 4000,
+            "refresh" : 500,
             "rel" : [
                "create-form"
             ],


### PR DESCRIPTION
Fixes #145, as well as improve test coverage and clarity / readability within the PollHandler.