### PR TITLE
Fix "Multiple commands produce PrivacyInfo.xcprivacy" error

### DIFF
--- a/OktaIdx.podspec
+++ b/OktaIdx.podspec
@@ -22,7 +22,7 @@ Integrate your native app with Okta using the Okta Identity Engine library.
   spec.source           = { :git => 'https://github.com/okta/okta-idx-swift.git', :tag => spec.version.to_s }
 
   spec.source_files = 'Sources/OktaIdx/**/*.swift'
-  spec.resources    = 'Sources/OktaIdx/Resources/**/*'
+  spec.resource_bundles = { 'OktaIdx' => 'Sources/Resources/**/*' }
   spec.swift_version = "5.6"
 
   spec.dependency "OktaAuthFoundation", "~> 1.7.0"

--- a/OktaIdx.podspec
+++ b/OktaIdx.podspec
@@ -22,7 +22,7 @@ Integrate your native app with Okta using the Okta Identity Engine library.
   spec.source           = { :git => 'https://github.com/okta/okta-idx-swift.git', :tag => spec.version.to_s }
 
   spec.source_files = 'Sources/OktaIdx/**/*.swift'
-  spec.resource_bundles = { 'OktaIdx' => 'Sources/Resources/**/*' }
+  spec.resource_bundles = { 'OktaIdx' => 'Sources/OktaIdx/Resources/**/*' }
   spec.swift_version = "5.6"
 
   spec.dependency "OktaAuthFoundation", "~> 1.7.0"


### PR DESCRIPTION
This PR changes the inclusion of PrivacyInfo.xcprivacy to resource_bundles for cocoapod to avoid resource name collision when the user uses cocoapod as static library.

See 

https://jochen-holzer.medium.com/required-reason-api-troubleshooting-your-ios-privacy-manifest-file-privacyinfo-xcprivacy-c81084dc9d51

https://github.com/getsentry/sentry-cocoa/pull/3651